### PR TITLE
🔒 Fix: Sensitive PII Logged to Console

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -78,11 +78,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }, 5000);
 
         const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-            console.log("AuthProvider: Auth state changed", currentUser?.email);
+            console.log("AuthProvider: Auth state changed");
             if (currentUser) {
                 try {
                     const emailRef = doc(db, 'allowed_users', currentUser.email!);
-                    console.log("AuthProvider: Checking authorization for path:", emailRef.path);
+                    console.log("AuthProvider: Checking authorization...");
                     const emailDoc = await getDoc(emailRef);
 
                     if (mounted) {
@@ -90,7 +90,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                             console.log("AuthProvider: User is authorized");
                             setIsAuthorized(true);
                         } else {
-                            console.warn("AuthProvider: User not in allowed_users list:", currentUser.email);
+                            console.warn("AuthProvider: User not in allowed_users list");
                             setIsAuthorized(false);
                         }
                     }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -231,7 +231,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
         if (!user) return; // Wait for auth
 
-        console.log("Store: Subscribing to user data for", user.uid);
+        console.log("Store: Subscribing to user data");
         const unsubscribe = subscribeToUserData(user.uid, (data) => {
             rawDispatch({ type: 'LOAD_DATA', payload: data });
         });


### PR DESCRIPTION
This change removes sensitive Personally Identifiable Information (PII) from console logs in `src/contexts/AuthContext.tsx` and `src/store.tsx`. 

Specifically:
- In `src/contexts/AuthContext.tsx`, `currentUser?.email` and `emailRef.path` (which contains the email) were being logged. These have been removed or replaced with generic messages.
- In `src/store.tsx`, `user.uid` was being logged. This has been removed.

Logging PII like emails and UIDs to the browser console is a security risk as these logs can be accessed by unauthorized parties with access to the client machine or through monitoring tools.

---
*PR created automatically by Jules for task [3942403911744818132](https://jules.google.com/task/3942403911744818132) started by @mrembert*