### PR TITLE
🧪 Extract and test note content cleaning logic

### DIFF
--- a/src/lib/noteUtils.test.ts
+++ b/src/lib/noteUtils.test.ts
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { cleanNoteContent } from './noteUtils.ts';
+import type { Bullet } from '../types.ts';
+
+const mockBullets: Record<string, any> = {
+    'bullet-1': { id: 'bullet-1', content: 'Task 1', type: 'task', state: 'open', order: 1, createdAt: 123, updatedAt: 123 },
+    'bullet-2': { id: 'bullet-2', content: 'Task 2', type: 'task', state: 'open', order: 2, createdAt: 124, updatedAt: 124 },
+};
+
+test('cleanNoteContent - basic cleaning', () => {
+    const rawContent = JSON.stringify({
+        type: 'doc',
+        content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] },
+            { type: 'embeddedTask', attrs: { bulletId: 'bullet-1' } },
+            { type: 'embeddedTask', attrs: { bulletId: 'non-existent' } },
+        ]
+    });
+
+    const cleaned = cleanNoteContent(rawContent, mockBullets as Record<string, Bullet>);
+    const parsed = JSON.parse(cleaned);
+
+    assert.strictEqual(parsed.content.length, 2);
+    assert.strictEqual(parsed.content[0].type, 'paragraph');
+    assert.strictEqual(parsed.content[1].type, 'embeddedTask');
+    assert.strictEqual(parsed.content[1].attrs.bulletId, 'bullet-1');
+});
+
+test('cleanNoteContent - recursive cleaning', () => {
+    const rawContent = JSON.stringify({
+        type: 'doc',
+        content: [
+            {
+                type: 'bulletList',
+                content: [
+                    {
+                        type: 'listItem',
+                        content: [
+                            { type: 'paragraph', content: [{ type: 'text', text: 'Some text' }] },
+                            { type: 'embeddedTask', attrs: { bulletId: 'non-existent' } },
+                            { type: 'embeddedTask', attrs: { bulletId: 'bullet-2' } },
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+
+    const cleaned = cleanNoteContent(rawContent, mockBullets as Record<string, Bullet>);
+    const parsed = JSON.parse(cleaned);
+
+    const listItemContent = parsed.content[0].content[0].content;
+    assert.strictEqual(listItemContent.length, 2);
+    assert.strictEqual(listItemContent[0].type, 'paragraph');
+    assert.strictEqual(listItemContent[1].type, 'embeddedTask');
+    assert.strictEqual(listItemContent[1].attrs.bulletId, 'bullet-2');
+});
+
+test('cleanNoteContent - preservation', () => {
+    const rawContent = JSON.stringify({
+        type: 'doc',
+        content: [
+            { type: 'embeddedTask', attrs: { bulletId: 'bullet-1' } },
+            { type: 'embeddedTask', attrs: { bulletId: 'bullet-2' } },
+        ]
+    });
+
+    const cleaned = cleanNoteContent(rawContent, mockBullets as Record<string, Bullet>);
+    const parsed = JSON.parse(cleaned);
+
+    assert.strictEqual(parsed.content.length, 2);
+});
+
+test('cleanNoteContent - handles empty or invalid input', () => {
+    assert.strictEqual(cleanNoteContent('', mockBullets as Record<string, Bullet>), '');
+    assert.strictEqual(cleanNoteContent('invalid-json', mockBullets as Record<string, Bullet>), 'invalid-json');
+});
+
+test('cleanNoteContent - handles JSON without content array', () => {
+    const raw = JSON.stringify({ type: 'doc' });
+    assert.strictEqual(cleanNoteContent(raw, mockBullets as Record<string, Bullet>), raw);
+});
+
+test('cleanNoteContent - handles null or missing attrs/bulletId', () => {
+    const rawContent = JSON.stringify({
+        type: 'doc',
+        content: [
+            { type: 'embeddedTask' },
+            { type: 'embeddedTask', attrs: {} },
+            { type: 'embeddedTask', attrs: { bulletId: null } },
+        ]
+    });
+
+    const cleaned = cleanNoteContent(rawContent, mockBullets as Record<string, Bullet>);
+    const parsed = JSON.parse(cleaned);
+
+    assert.strictEqual(parsed.content.length, 3);
+});

--- a/src/lib/noteUtils.ts
+++ b/src/lib/noteUtils.ts
@@ -1,0 +1,39 @@
+import type { Bullet } from '../types.ts';
+
+/**
+ * Cleans the note content by removing orphaned embeddedTask nodes.
+ * An embeddedTask node is considered orphaned if its associated bulletId
+ * does not exist in the current state.
+ *
+ * This function recursively traverses the content tree to find and remove
+ * orphaned nodes at any level.
+ *
+ * @param raw - The JSON string representation of the note content.
+ * @param bullets - A record of existing bullets.
+ * @returns The cleaned JSON string.
+ */
+export function cleanNoteContent(raw: string, bullets: Record<string, Bullet>): string {
+    if (!raw) return '';
+    try {
+        const parsed = JSON.parse(raw);
+
+        const cleanNodes = (nodes: any[]): any[] => {
+            return nodes.filter((node: any) => {
+                if (node.type === 'embeddedTask' && node.attrs?.bulletId) {
+                    return !!bullets[node.attrs.bulletId];
+                }
+                if (node.content && Array.isArray(node.content)) {
+                    node.content = cleanNodes(node.content);
+                }
+                return true;
+            });
+        };
+
+        if (parsed && Array.isArray(parsed.content)) {
+            parsed.content = cleanNodes(parsed.content);
+        }
+        return JSON.stringify(parsed);
+    } catch {
+        return raw;
+    }
+}


### PR DESCRIPTION
Extracted the note content cleaning logic from `src/components/NoteEditor.tsx` into a pure utility function `cleanNoteContent` in `src/lib/noteUtils.ts`. 

Improved the logic to recursively traverse the content tree, ensuring that orphaned `embeddedTask` nodes are removed even when nested (e.g., inside lists or blockquotes).

Implemented comprehensive unit tests using Node.js's built-in `node:test` and `node:assert` modules, covering basic cleaning, recursive cleaning, preservation of valid tasks, and various edge cases. 

Verified the implementation by running the tests with `node --test --experimental-strip-types`.

---
*PR created automatically by Jules for task [14082197322592496247](https://jules.google.com/task/14082197322592496247) started by @mrembert*