### PR TITLE
🔒 Security Fix: Enforce Server-Side Authorization in Firestore Rules

### DIFF
--- a/SECURITY_VERIFICATION.md
+++ b/SECURITY_VERIFICATION.md
@@ -1,0 +1,40 @@
+# Security Verification: Firestore Rules Update
+
+## Vulnerability
+
+The `firestore.rules` file contained a commented-out authorization check, which meant that server-side enforcement of user authorization was missing. Users could potentially access their own data even if they were not in the `allowed_users` collection, bypassing the application's intended access control.
+
+**Vulnerable Code:**
+```javascript
+// allow read, write: if request.auth != null && request.auth.uid == userId && exists(/databases/$(database)/documents/allowed_users/$(request.auth.token.email));
+```
+
+## Fix
+
+The fix involves uncommenting and refining the authorization check to ensure that a user can only read/write to `users/{userId}` if:
+1.  They are authenticated (`request.auth != null`).
+2.  Their UID matches the path (`request.auth.uid == userId`).
+3.  Their email exists in the `allowed_users` collection (`exists(...)`).
+4.  Their email claim is present (`request.auth.token.email != null`).
+
+**Fixed Code:**
+```javascript
+allow read, write: if request.auth != null && request.auth.uid == userId &&
+                   request.auth.token.email != null &&
+                   exists(/databases/$(database)/documents/allowed_users/$(request.auth.token.email));
+```
+
+## Verification Logic
+
+Due to environment restrictions (unable to install dependencies or run Firebase emulators), automated tests could not be executed. However, the logic has been manually verified against the application's authentication flow:
+
+1.  **Client-Side Check:** `AuthContext.tsx` verifies user authorization by checking for a document in `allowed_users` with the ID matching the user's email.
+    ```typescript
+    const emailRef = doc(db, 'allowed_users', currentUser.email!);
+    const emailDoc = await getDoc(emailRef);
+    ```
+2.  **Server-Side Check:** The updated Firestore rule mirrors this logic securely on the server side.
+    -   It uses `request.auth.token.email` which corresponds to `currentUser.email`.
+    -   It checks existence in `allowed_users` collection.
+
+This ensures consistency between client-side behavior and server-side enforcement.

--- a/firestore.rules
+++ b/firestore.rules
@@ -15,10 +15,9 @@ service cloud.firestore {
     // 2. Allow users to read/write their OWN data
     match /users/{userId}/{document=**} {
       // Check if the requesting user matches the path userId
-      allow read, write: if request.auth != null && request.auth.uid == userId;
-      
-      // OPTIONAL: Add a refined check to ensure they are ALSO in allowed_users
-      // allow read, write: if request.auth != null && request.auth.uid == userId && exists(/databases/$(database)/documents/allowed_users/$(request.auth.token.email));
+      allow read, write: if request.auth != null && request.auth.uid == userId &&
+                         request.auth.token.email != null &&
+                         exists(/databases/$(database)/documents/allowed_users/$(request.auth.token.email));
     }
   }
 }


### PR DESCRIPTION
This PR addresses a critical security vulnerability where server-side authorization was not enforced. 

Previously, users could read/write their own data (`users/{userId}`) without being verified against the `allowed_users` collection. This fix enforces that check, ensuring only authorized users can access the database.

It also adds a null check for `request.auth.token.email` to prevent errors if the email claim is missing.

Manual verification steps are documented in `SECURITY_VERIFICATION.md` as automated tests could not be run in the restricted environment.

---
*PR created automatically by Jules for task [7220276215914119862](https://jules.google.com/task/7220276215914119862) started by @mrembert*