### PR TITLE
🔒 Fix: Restrict Mock Auth Bypass to Development Only

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,7 +29,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [isAuthorized, setIsAuthorized] = useState(false);
 
     useEffect(() => {
-        const useMockAuth = import.meta.env.VITE_USE_MOCK_AUTH === 'true';
+        // Only allow mock auth in development mode to prevent production bypass
+        const useMockAuth = import.meta.env.DEV && import.meta.env.VITE_USE_MOCK_AUTH === 'true';
 
         if (useMockAuth) {
             console.log("AuthProvider: Mock Auth Enabled");


### PR DESCRIPTION
# 🔒 Security Fix: Mock Authentication Bypass

## 🎯 What
This PR addresses a critical security vulnerability where the mock authentication mechanism could be enabled in a production environment by simply setting the `VITE_USE_MOCK_AUTH` environment variable to 'true'.

## ⚠️ Risk
If `VITE_USE_MOCK_AUTH` were accidentally set in a production build, any user visiting the site would be automatically logged in as a privileged mock user, bypassing all authentication and authorization checks. This could lead to unauthorized access to sensitive data and application functionality.

## 🛡️ Solution
The fix introduces an additional check for `import.meta.env.DEV` in `src/contexts/AuthContext.tsx`. This ensures that the mock authentication logic is only executable when the application is running in development mode (e.g., via `vite dev`), regardless of the environment variable's value. In production builds, this code path will be unreachable and likely eliminated by the bundler.

## ✅ Verification
- Verified that existing tests pass (`src/lib/noteUtils.test.ts`).
- Confirmed the code logic explicitly prevents the bypass in non-development environments.

---
*PR created automatically by Jules for task [2787076748784505920](https://jules.google.com/task/2787076748784505920) started by @mrembert*