### PR TITLE
Refactor: Extract Reducer to Pure Module and Add Tests

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,20 @@
+// Helper for UUID generation (using native crypto)
+export function generateUUID(): string {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+    // Fallback for older environments
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+// Helper for date formatting (YYYY-MM-DD)
+export function getTodayDate(): string {
+    const d = new Date();
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,216 +1,9 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
-import type { AppState, Bullet, Collection, BulletType, ViewMode, BulletState } from './types';
-import { v4 as uuidv4 } from 'uuid';
-import { format } from 'date-fns';
+import type { AppState } from './types';
 import { useAuth } from './contexts/AuthContext';
 import { performActionInFirestore, subscribeToUserData } from './lib/database';
-
-// --- Actions ---
-// NOTE: We now require IDs for creation actions because the Dispatch wrapper generates them
-// to ensure consistency between Local Optimistic UI and Firestore Write.
-type Action =
-    | { type: 'ADD_BULLET'; payload: { id: string; content: string; type: BulletType; date?: string; collectionId?: string } }
-    | { type: 'UPDATE_BULLET'; payload: { id: string; content?: string; state?: BulletState; longFormContent?: string; date?: string | null; collectionId?: string | null } }
-    | { type: 'DELETE_BULLET'; payload: { id: string } }
-    | { type: 'SET_VIEW'; payload: { mode: ViewMode; date?: string; collectionId?: string } }
-    | { type: 'ADD_COLLECTION'; payload: { id: string; title: string; type: Collection['type'] } }
-    | { type: 'UPDATE_COLLECTION'; payload: { id: string; title?: string; archived?: boolean } }
-    | { type: 'DELETE_COLLECTION'; payload: { id: string } }
-    | { type: 'MIGRATE_BULLET'; payload: { id: string; targetDate: string; newId?: string } }
-    | { type: 'REORDER_BULLETS'; payload: { items: { id: string, order: number }[] } }
-    | { type: 'TOGGLE_PREFERENCE'; payload: { key: keyof AppState['preferences'] } }
-    | { type: 'LOAD_DATA'; payload: Partial<AppState> }; // Partial loading for sync
-
-// --- Initial State ---
-const initialState: AppState = {
-    bullets: {},
-    collections: {},
-    view: {
-        mode: 'daily',
-        date: format(new Date(), 'yyyy-MM-dd'),
-    },
-    preferences: {
-        groupByProject: false,
-        showCompleted: true,
-        showMigrated: false,
-    },
-};
-
-// --- Reducer ---
-function reducer(state: AppState, action: Action): AppState {
-    switch (action.type) {
-        case 'ADD_BULLET': {
-            const { id, ...data } = action.payload;
-            const now = Date.now();
-            const newBullet: Bullet = {
-                id,
-                ...data, // content, type, date, collectionId
-                state: 'open',
-                order: now,
-                createdAt: now,
-                updatedAt: now,
-            };
-            return {
-                ...state,
-                bullets: { ...state.bullets, [id]: newBullet },
-            };
-        }
-        case 'UPDATE_BULLET': {
-            const bullet = state.bullets[action.payload.id];
-            if (!bullet) return state;
-
-            const updates: Partial<Bullet> = {
-                ...action.payload,
-                updatedAt: Date.now(),
-            };
-
-            // Handle completion timestamp
-            if (action.payload.state === 'completed' && bullet.state !== 'completed') {
-                updates.completedAt = Date.now();
-            } else if (action.payload.state === 'open' && bullet.state === 'completed') {
-                updates.completedAt = undefined;
-            }
-
-            return {
-                ...state,
-                bullets: {
-                    ...state.bullets,
-                    [action.payload.id]: {
-                        ...bullet,
-                        ...updates,
-                    },
-                },
-            };
-        }
-        case 'REORDER_BULLETS': {
-            const newBullets = { ...state.bullets };
-            // Ensure we handle potential undefined bullets gracefully
-            action.payload.items.forEach(({ id, order }) => {
-                if (newBullets[id]) {
-                    newBullets[id] = { ...newBullets[id], order };
-                }
-            });
-            return { ...state, bullets: newBullets };
-        }
-        case 'DELETE_BULLET': {
-            const { [action.payload.id]: deleted, ...remainingBullets } = state.bullets;
-            return { ...state, bullets: remainingBullets };
-        }
-        case 'MIGRATE_BULLET': {
-            const oldBullet = state.bullets[action.payload.id];
-            if (!oldBullet) return state;
-
-            // If it belongs to a collection, we just schedule it (update date), we don't clone it.
-            if (oldBullet.collectionId) {
-                return {
-                    ...state,
-                    bullets: {
-                        ...state.bullets,
-                        [oldBullet.id]: {
-                            ...oldBullet,
-                            date: action.payload.targetDate,
-                            updatedAt: Date.now(),
-                        }
-                    }
-                };
-            }
-
-            // Normal migration (Task -> Next Day)
-            const newId = action.payload.newId || uuidv4();
-            const now = Date.now();
-
-            return {
-                ...state,
-                bullets: {
-                    ...state.bullets,
-                    [oldBullet.id]: { ...oldBullet, state: 'migrated', updatedAt: now },
-                    [newId]: {
-                        ...oldBullet,
-                        id: newId,
-                        date: action.payload.targetDate,
-                        state: 'open',
-                        order: now,
-                        createdAt: now,
-                        updatedAt: now,
-                    },
-                },
-            };
-        }
-        case 'SET_VIEW': {
-            return {
-                ...state,
-                view: {
-                    mode: action.payload.mode,
-                    date: action.payload.date || state.view.date,
-                    collectionId: action.payload.collectionId,
-                },
-            };
-        }
-        case 'ADD_COLLECTION': {
-            const { id, ...data } = action.payload;
-            const now = Date.now();
-            return {
-                ...state,
-                collections: {
-                    ...state.collections,
-                    [id]: {
-                        id,
-                        title: data.title,
-                        type: data.type,
-                        createdAt: now,
-                    },
-                },
-            };
-        }
-        case 'UPDATE_COLLECTION': {
-            const collection = state.collections[action.payload.id];
-            if (!collection) return state;
-
-            return {
-                ...state,
-                collections: {
-                    ...state.collections,
-                    [action.payload.id]: {
-                        ...collection,
-                        ...action.payload,
-                    }
-                }
-            };
-        }
-        case 'DELETE_COLLECTION': {
-            const { [action.payload.id]: deleted, ...remainingCollections } = state.collections;
-            return {
-                ...state,
-                collections: remainingCollections
-            };
-        }
-        case 'TOGGLE_PREFERENCE': {
-            return {
-                ...state,
-                preferences: {
-                    ...state.preferences,
-                    [action.payload.key]: !state.preferences[action.payload.key]
-                }
-            };
-        }
-        case 'LOAD_DATA': {
-            const newState = {
-                ...state,
-                bullets: { ...state.bullets, ...(action.payload.bullets || {}) },
-                collections: { ...state.collections, ...(action.payload.collections || {}) },
-            };
-            // Preserve local preferences if not in payload, or maybe we want to sync them?
-            // For now, let's assume preferences are local-only or we can sync them if we add them to Firestore.
-            // But since payload is Partial<AppState>, if preferences are there, we take them.
-            if (action.payload.preferences) {
-                newState.preferences = { ...state.preferences, ...action.payload.preferences };
-            }
-            return newState;
-        }
-        default:
-            return state;
-    }
-}
+import { reducer, initialState, type Action } from './storeReducer';
+import { generateUUID } from './lib/utils';
 
 // --- Context ---
 const StoreContext = createContext<{
@@ -246,14 +39,14 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
         let enhancedAction = { ...action };
 
         if (action.type === 'ADD_BULLET' && !action.payload.id) {
-            enhancedAction.payload.id = uuidv4();
+            enhancedAction.payload.id = generateUUID();
         }
         if (action.type === 'ADD_COLLECTION' && !action.payload.id) {
-            enhancedAction.payload.id = uuidv4();
+            enhancedAction.payload.id = generateUUID();
         }
         if (action.type === 'MIGRATE_BULLET' && !action.payload.newId) {
             // Only if not collection-based. But safely we can just generate one.
-            enhancedAction.payload.newId = uuidv4();
+            enhancedAction.payload.newId = generateUUID();
         }
 
         // 1. Optimistic Update (Local)

--- a/src/storeReducer.test.ts
+++ b/src/storeReducer.test.ts
@@ -1,0 +1,282 @@
+import test, { describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { reducer, initialState } from './storeReducer.ts';
+import type { Action } from './storeReducer.ts';
+import type { AppState, Bullet, BulletType } from './types.ts';
+
+const FIXED_TIME = 1625097600000; // 2021-07-01T00:00:00.000Z
+
+describe('storeReducer', () => {
+    let originalDateNow: () => number;
+
+    beforeEach(() => {
+        originalDateNow = Date.now;
+        Date.now = () => FIXED_TIME;
+    });
+
+    afterEach(() => {
+        Date.now = originalDateNow;
+    });
+
+    test('ADD_BULLET adds a new bullet', () => {
+        const action: Action = {
+            type: 'ADD_BULLET',
+            payload: {
+                id: 'b1',
+                content: 'New Task',
+                type: 'task',
+                date: '2021-07-01'
+            }
+        };
+        const state = reducer(initialState, action);
+        assert.ok(state.bullets['b1']);
+        assert.strictEqual(state.bullets['b1'].content, 'New Task');
+        assert.strictEqual(state.bullets['b1'].state, 'open');
+        assert.strictEqual(state.bullets['b1'].createdAt, FIXED_TIME);
+        assert.strictEqual(state.bullets['b1'].updatedAt, FIXED_TIME);
+    });
+
+    test('UPDATE_BULLET updates content', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': {
+                    id: 'b1',
+                    content: 'Old Content',
+                    type: 'task',
+                    state: 'open',
+                    order: 100,
+                    createdAt: 100,
+                    updatedAt: 100
+                }
+            }
+        };
+
+        const action: Action = {
+            type: 'UPDATE_BULLET',
+            payload: { id: 'b1', content: 'New Content' }
+        };
+
+        const state = reducer(startState, action);
+        assert.strictEqual(state.bullets['b1'].content, 'New Content');
+        assert.strictEqual(state.bullets['b1'].updatedAt, FIXED_TIME);
+    });
+
+    test('UPDATE_BULLET handles completion state', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': {
+                    id: 'b1',
+                    content: 'Task',
+                    type: 'task',
+                    state: 'open',
+                    order: 100,
+                    createdAt: 100,
+                    updatedAt: 100
+                }
+            }
+        };
+
+        const action: Action = {
+            type: 'UPDATE_BULLET',
+            payload: { id: 'b1', state: 'completed' }
+        };
+
+        const state = reducer(startState, action);
+        assert.strictEqual(state.bullets['b1'].state, 'completed');
+        assert.strictEqual(state.bullets['b1'].completedAt, FIXED_TIME);
+
+        // Toggle back to open
+        const action2: Action = {
+            type: 'UPDATE_BULLET',
+            payload: { id: 'b1', state: 'open' }
+        };
+
+        // Advance time for second update
+        Date.now = () => FIXED_TIME + 1000;
+        const state2 = reducer(state, action2);
+        assert.strictEqual(state2.bullets['b1'].state, 'open');
+        assert.strictEqual(state2.bullets['b1'].completedAt, undefined);
+        assert.strictEqual(state2.bullets['b1'].updatedAt, FIXED_TIME + 1000);
+    });
+
+    test('DELETE_BULLET removes a bullet', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': { id: 'b1', content: 'Task', type: 'task', state: 'open', order: 1, createdAt: 1, updatedAt: 1 }
+            }
+        };
+
+        const action: Action = { type: 'DELETE_BULLET', payload: { id: 'b1' } };
+        const state = reducer(startState, action);
+        assert.strictEqual(state.bullets['b1'], undefined);
+    });
+
+    test('SET_VIEW updates view state', () => {
+        const action: Action = {
+            type: 'SET_VIEW',
+            payload: { mode: 'week', date: '2021-07-05' }
+        };
+        const state = reducer(initialState, action);
+        assert.strictEqual(state.view.mode, 'week');
+        assert.strictEqual(state.view.date, '2021-07-05');
+    });
+
+    test('ADD_COLLECTION adds a collection', () => {
+        const action: Action = {
+            type: 'ADD_COLLECTION',
+            payload: { id: 'c1', title: 'Project X', type: 'project' }
+        };
+        const state = reducer(initialState, action);
+        assert.ok(state.collections['c1']);
+        assert.strictEqual(state.collections['c1'].title, 'Project X');
+        assert.strictEqual(state.collections['c1'].type, 'project');
+        assert.strictEqual(state.collections['c1'].createdAt, FIXED_TIME);
+    });
+
+    test('UPDATE_COLLECTION updates collection', () => {
+        const startState: AppState = {
+            ...initialState,
+            collections: {
+                'c1': { id: 'c1', title: 'Old Title', type: 'project', createdAt: 100 }
+            }
+        };
+        const action: Action = {
+            type: 'UPDATE_COLLECTION',
+            payload: { id: 'c1', title: 'New Title' }
+        };
+        const state = reducer(startState, action);
+        assert.strictEqual(state.collections['c1'].title, 'New Title');
+    });
+
+    test('DELETE_COLLECTION removes collection', () => {
+        const startState: AppState = {
+            ...initialState,
+            collections: {
+                'c1': { id: 'c1', title: 'Project', type: 'project', createdAt: 100 }
+            }
+        };
+        const action: Action = { type: 'DELETE_COLLECTION', payload: { id: 'c1' } };
+        const state = reducer(startState, action);
+        assert.strictEqual(state.collections['c1'], undefined);
+    });
+
+    test('MIGRATE_BULLET (standard) moves task to new day', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': {
+                    id: 'b1',
+                    content: 'Task',
+                    type: 'task',
+                    state: 'open',
+                    date: '2021-07-01',
+                    order: 1,
+                    createdAt: 100,
+                    updatedAt: 100
+                }
+            }
+        };
+
+        const action: Action = {
+            type: 'MIGRATE_BULLET',
+            payload: { id: 'b1', targetDate: '2021-07-02', newId: 'b2' }
+        };
+
+        const state = reducer(startState, action);
+
+        // Old bullet should be migrated
+        assert.strictEqual(state.bullets['b1'].state, 'migrated');
+        assert.strictEqual(state.bullets['b1'].updatedAt, FIXED_TIME);
+
+        // New bullet should be created
+        assert.ok(state.bullets['b2']);
+        assert.strictEqual(state.bullets['b2'].content, 'Task');
+        assert.strictEqual(state.bullets['b2'].date, '2021-07-02');
+        assert.strictEqual(state.bullets['b2'].state, 'open');
+        assert.strictEqual(state.bullets['b2'].createdAt, FIXED_TIME);
+    });
+
+    test('MIGRATE_BULLET (collection) updates date only', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': {
+                    id: 'b1',
+                    content: 'Project Task',
+                    type: 'task',
+                    state: 'open',
+                    collectionId: 'c1',
+                    date: '2021-07-01',
+                    order: 1,
+                    createdAt: 100,
+                    updatedAt: 100
+                }
+            }
+        };
+
+        const action: Action = {
+            type: 'MIGRATE_BULLET',
+            payload: { id: 'b1', targetDate: '2021-07-02' }
+        };
+
+        const state = reducer(startState, action);
+
+        // Should update existing bullet
+        assert.strictEqual(state.bullets['b1'].date, '2021-07-02');
+        assert.strictEqual(state.bullets['b1'].state, 'open'); // Should remain open
+        assert.strictEqual(state.bullets['b1'].updatedAt, FIXED_TIME);
+    });
+
+    test('REORDER_BULLETS updates order', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': { id: 'b1', order: 1, content: 'A', type: 'task', state: 'open', createdAt: 1, updatedAt: 1 },
+                'b2': { id: 'b2', order: 2, content: 'B', type: 'task', state: 'open', createdAt: 1, updatedAt: 1 }
+            }
+        };
+
+        const action: Action = {
+            type: 'REORDER_BULLETS',
+            payload: { items: [{ id: 'b1', order: 2 }, { id: 'b2', order: 1 }] }
+        };
+
+        const state = reducer(startState, action);
+        assert.strictEqual(state.bullets['b1'].order, 2);
+        assert.strictEqual(state.bullets['b2'].order, 1);
+    });
+
+    test('TOGGLE_PREFERENCE toggles boolean value', () => {
+        const action: Action = {
+            type: 'TOGGLE_PREFERENCE',
+            payload: { key: 'showCompleted' }
+        };
+        // Initial showCompleted is true
+        const state = reducer(initialState, action);
+        assert.strictEqual(state.preferences.showCompleted, false);
+
+        const state2 = reducer(state, action);
+        assert.strictEqual(state2.preferences.showCompleted, true);
+    });
+
+    test('LOAD_DATA merges data', () => {
+        const action: Action = {
+            type: 'LOAD_DATA',
+            payload: {
+                bullets: {
+                    'loaded': { id: 'loaded', content: 'Loaded', type: 'task', state: 'open', order: 1, createdAt: 1, updatedAt: 1 }
+                },
+                preferences: {
+                    groupByProject: true
+                }
+            }
+        };
+
+        const state = reducer(initialState, action);
+        assert.ok(state.bullets['loaded']);
+        assert.strictEqual(state.preferences.groupByProject, true);
+    });
+});

--- a/src/storeReducer.ts
+++ b/src/storeReducer.ts
@@ -1,0 +1,209 @@
+import type { AppState, Bullet, Collection, BulletType, ViewMode, BulletState } from './types';
+import { generateUUID, getTodayDate } from './lib/utils.ts';
+
+// --- Actions ---
+// NOTE: We now require IDs for creation actions because the Dispatch wrapper generates them
+// to ensure consistency between Local Optimistic UI and Firestore Write.
+export type Action =
+    | { type: 'ADD_BULLET'; payload: { id: string; content: string; type: BulletType; date?: string; collectionId?: string } }
+    | { type: 'UPDATE_BULLET'; payload: { id: string; content?: string; state?: BulletState; longFormContent?: string; date?: string | null; collectionId?: string | null } }
+    | { type: 'DELETE_BULLET'; payload: { id: string } }
+    | { type: 'SET_VIEW'; payload: { mode: ViewMode; date?: string; collectionId?: string } }
+    | { type: 'ADD_COLLECTION'; payload: { id: string; title: string; type: Collection['type'] } }
+    | { type: 'UPDATE_COLLECTION'; payload: { id: string; title?: string; archived?: boolean } }
+    | { type: 'DELETE_COLLECTION'; payload: { id: string } }
+    | { type: 'MIGRATE_BULLET'; payload: { id: string; targetDate: string; newId?: string } }
+    | { type: 'REORDER_BULLETS'; payload: { items: { id: string, order: number }[] } }
+    | { type: 'TOGGLE_PREFERENCE'; payload: { key: keyof AppState['preferences'] } }
+    | { type: 'LOAD_DATA'; payload: Partial<AppState> }; // Partial loading for sync
+
+// --- Initial State ---
+export const initialState: AppState = {
+    bullets: {},
+    collections: {},
+    view: {
+        mode: 'daily',
+        date: getTodayDate(),
+    },
+    preferences: {
+        groupByProject: false,
+        showCompleted: true,
+        showMigrated: false,
+    },
+};
+
+// --- Reducer ---
+export function reducer(state: AppState, action: Action): AppState {
+    switch (action.type) {
+        case 'ADD_BULLET': {
+            const { id, ...data } = action.payload;
+            const now = Date.now();
+            const newBullet: Bullet = {
+                id,
+                ...data, // content, type, date, collectionId
+                state: 'open',
+                order: now,
+                createdAt: now,
+                updatedAt: now,
+            };
+            return {
+                ...state,
+                bullets: { ...state.bullets, [id]: newBullet },
+            };
+        }
+        case 'UPDATE_BULLET': {
+            const bullet = state.bullets[action.payload.id];
+            if (!bullet) return state;
+
+            const updates: Partial<Bullet> = {
+                ...action.payload,
+                updatedAt: Date.now(),
+            };
+
+            // Handle completion timestamp
+            if (action.payload.state === 'completed' && bullet.state !== 'completed') {
+                updates.completedAt = Date.now();
+            } else if (action.payload.state === 'open' && bullet.state === 'completed') {
+                updates.completedAt = undefined;
+            }
+
+            return {
+                ...state,
+                bullets: {
+                    ...state.bullets,
+                    [action.payload.id]: {
+                        ...bullet,
+                        ...updates,
+                    },
+                },
+            };
+        }
+        case 'REORDER_BULLETS': {
+            const newBullets = { ...state.bullets };
+            // Ensure we handle potential undefined bullets gracefully
+            action.payload.items.forEach(({ id, order }) => {
+                if (newBullets[id]) {
+                    newBullets[id] = { ...newBullets[id], order };
+                }
+            });
+            return { ...state, bullets: newBullets };
+        }
+        case 'DELETE_BULLET': {
+            const { [action.payload.id]: deleted, ...remainingBullets } = state.bullets;
+            return { ...state, bullets: remainingBullets };
+        }
+        case 'MIGRATE_BULLET': {
+            const oldBullet = state.bullets[action.payload.id];
+            if (!oldBullet) return state;
+
+            // If it belongs to a collection, we just schedule it (update date), we don't clone it.
+            if (oldBullet.collectionId) {
+                return {
+                    ...state,
+                    bullets: {
+                        ...state.bullets,
+                        [oldBullet.id]: {
+                            ...oldBullet,
+                            date: action.payload.targetDate,
+                            updatedAt: Date.now(),
+                        }
+                    }
+                };
+            }
+
+            // Normal migration (Task -> Next Day)
+            const newId = action.payload.newId || generateUUID();
+            const now = Date.now();
+
+            return {
+                ...state,
+                bullets: {
+                    ...state.bullets,
+                    [oldBullet.id]: { ...oldBullet, state: 'migrated', updatedAt: now },
+                    [newId]: {
+                        ...oldBullet,
+                        id: newId,
+                        date: action.payload.targetDate,
+                        state: 'open',
+                        order: now,
+                        createdAt: now,
+                        updatedAt: now,
+                    },
+                },
+            };
+        }
+        case 'SET_VIEW': {
+            return {
+                ...state,
+                view: {
+                    mode: action.payload.mode,
+                    date: action.payload.date || state.view.date,
+                    collectionId: action.payload.collectionId,
+                },
+            };
+        }
+        case 'ADD_COLLECTION': {
+            const { id, ...data } = action.payload;
+            const now = Date.now();
+            return {
+                ...state,
+                collections: {
+                    ...state.collections,
+                    [id]: {
+                        id,
+                        title: data.title,
+                        type: data.type,
+                        createdAt: now,
+                    },
+                },
+            };
+        }
+        case 'UPDATE_COLLECTION': {
+            const collection = state.collections[action.payload.id];
+            if (!collection) return state;
+
+            return {
+                ...state,
+                collections: {
+                    ...state.collections,
+                    [action.payload.id]: {
+                        ...collection,
+                        ...action.payload,
+                    }
+                }
+            };
+        }
+        case 'DELETE_COLLECTION': {
+            const { [action.payload.id]: deleted, ...remainingCollections } = state.collections;
+            return {
+                ...state,
+                collections: remainingCollections
+            };
+        }
+        case 'TOGGLE_PREFERENCE': {
+            return {
+                ...state,
+                preferences: {
+                    ...state.preferences,
+                    [action.payload.key]: !state.preferences[action.payload.key]
+                }
+            };
+        }
+        case 'LOAD_DATA': {
+            const newState = {
+                ...state,
+                bullets: { ...state.bullets, ...(action.payload.bullets || {}) },
+                collections: { ...state.collections, ...(action.payload.collections || {}) },
+            };
+            // Preserve local preferences if not in payload, or maybe we want to sync them?
+            // For now, let's assume preferences are local-only or we can sync them if we add them to Firestore.
+            // But since payload is Partial<AppState>, if preferences are there, we take them.
+            if (action.payload.preferences) {
+                newState.preferences = { ...state.preferences, ...action.payload.preferences };
+            }
+            return newState;
+        }
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
Extracted reducer logic from src/store.tsx to src/storeReducer.ts to enable unit testing. Added comprehensive tests in src/storeReducer.test.ts using node:test. Replaced external dependencies (uuid, date-fns) with native implementations (crypto.randomUUID, Date) to fix missing dependencies and ensure pure logic. This improves test coverage and reliability of the core state management logic.

---
*PR created automatically by Jules for task [15730096170005925893](https://jules.google.com/task/15730096170005925893) started by @mrembert*