### PR TITLE
Add inline editing for tasks

### DIFF
--- a/src/components/BulletItem.tsx
+++ b/src/components/BulletItem.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
-import { Trash, FileText, FolderInput, Calendar, MoreVertical } from 'lucide-react';
+import { Trash, FileText, FolderInput, Calendar, MoreVertical, Edit2 } from 'lucide-react';
 import type { Bullet } from '../types';
 import { useStore } from '../store';
 import { BulletIcon } from './BulletIcon';
@@ -7,6 +7,7 @@ import { DatePicker } from './DatePicker';
 import { ProjectPicker } from './ProjectPicker';
 import { useNoteEditor } from '../contexts/NoteEditorContext';
 import { useConfirmation } from '../contexts/ConfirmationContext';
+import { useKeyboardFocus } from '../contexts/KeyboardFocusContext';
 import { format, parseISO } from 'date-fns';
 
 interface BulletItemProps {
@@ -21,9 +22,38 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
     const [menuOpen, setMenuOpen] = useState(false);
     const { openNote } = useNoteEditor();
     const { requestConfirmation } = useConfirmation();
+    const { editingId, setEditingId } = useKeyboardFocus();
 
     const collection = bullet.collectionId ? state.collections[bullet.collectionId] : null;
     const showCollectionTag = collection && state.view.collectionId !== bullet.collectionId;
+
+    const isEditing = editingId === bullet.id;
+    const [editContent, setEditContent] = useState(bullet.content);
+
+    // Sync local edit content if bullet content changes while not editing
+    useEffect(() => {
+        if (!isEditing) {
+            setEditContent(bullet.content);
+        }
+    }, [bullet.content, isEditing]);
+
+    const handleEdit = () => {
+        setEditContent(bullet.content);
+        setEditingId(bullet.id);
+        setMenuOpen(false);
+    };
+
+    const handleSave = () => {
+        if (editContent.trim() !== bullet.content) {
+            dispatch({ type: 'UPDATE_BULLET', payload: { id: bullet.id, content: editContent.trim() } });
+        }
+        setEditingId(null);
+    };
+
+    const handleCancel = () => {
+        setEditContent(bullet.content);
+        setEditingId(null);
+    };
 
     const toggleState = () => {
         if (bullet.state === 'open') {
@@ -94,8 +124,36 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
                     <BulletIcon type={bullet.type} state={bullet.state} />
                 </button>
 
-                <span style={{ flex: 1, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                    {bullet.content}
+                <span
+                    style={{ flex: 1, display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+                    onClick={!isEditing ? handleEdit : undefined}
+                >
+                    {isEditing ? (
+                        <input
+                            autoFocus
+                            className="input"
+                            value={editContent}
+                            onChange={(e) => setEditContent(e.target.value)}
+                            onBlur={handleSave}
+                            onKeyDown={(e) => {
+                                e.stopPropagation(); // Prevent keyboard shortcuts
+                                if (e.key === 'Enter') handleSave();
+                                if (e.key === 'Escape') handleCancel();
+                            }}
+                            style={{
+                                padding: '2px 4px',
+                                fontSize: 'inherit',
+                                fontFamily: 'inherit',
+                                background: 'hsl(var(--color-bg-primary))',
+                                border: '1px solid hsl(var(--color-accent))',
+                                borderRadius: '4px',
+                                width: '100%',
+                                marginLeft: '-4px'
+                            }}
+                        />
+                    ) : (
+                        bullet.content
+                    )}
                     {showCollectionTag && (
                         <span style={{
                             fontSize: '0.7rem',
@@ -201,6 +259,15 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
                                     style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
                                 >
                                     <FileText size={14} /> {hasNote ? 'View Note' : 'Add Note'}
+                                </button>
+
+                                {/* Edit Text */}
+                                <button
+                                    onClick={handleEdit}
+                                    className="btn btn-ghost"
+                                    style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
+                                >
+                                    <Edit2 size={14} /> Edit Text
                                 </button>
 
                                 {/* Project Picker */}

--- a/src/components/ShortcutsOverlay.tsx
+++ b/src/components/ShortcutsOverlay.tsx
@@ -9,6 +9,7 @@ export function ShortcutsOverlay({ onClose }: ShortcutsOverlayProps) {
     const shortcuts = [
         { key: 'j / ↓', desc: 'Focus next item' },
         { key: 'k / ↑', desc: 'Focus previous item' },
+        { key: 'e', desc: 'Edit text of focused item' },
         { key: 'x', desc: 'Toggle done on focused item' },
         { key: 'n', desc: 'Open note for focused item' },
         { key: 'm', desc: 'Migrate focused item' },

--- a/src/contexts/KeyboardFocusContext.tsx
+++ b/src/contexts/KeyboardFocusContext.tsx
@@ -4,6 +4,8 @@ import React, { createContext, useContext, useState, useCallback, useEffect } fr
 interface KeyboardFocusContextType {
     focusedId: string | null;
     setFocusedId: (id: string | null) => void;
+    editingId: string | null;
+    setEditingId: (id: string | null) => void;
     visibleIds: string[];
     setVisibleIds: (ids: string[]) => void;
     moveUp: () => void;
@@ -14,6 +16,8 @@ interface KeyboardFocusContextType {
 const KeyboardFocusContext = createContext<KeyboardFocusContextType>({
     focusedId: null,
     setFocusedId: () => { },
+    editingId: null,
+    setEditingId: () => { },
     visibleIds: [],
     setVisibleIds: () => { },
     moveUp: () => { },
@@ -23,6 +27,7 @@ const KeyboardFocusContext = createContext<KeyboardFocusContextType>({
 
 export function KeyboardFocusProvider({ children }: { children: React.ReactNode }) {
     const [focusedId, setFocusedId] = useState<string | null>(null);
+    const [editingId, setEditingId] = useState<string | null>(null);
     const [visibleIds, setVisibleIds] = useState<string[]>([]);
 
     const moveUp = useCallback(() => {
@@ -59,6 +64,8 @@ export function KeyboardFocusProvider({ children }: { children: React.ReactNode 
         <KeyboardFocusContext.Provider value={{
             focusedId,
             setFocusedId,
+            editingId,
+            setEditingId,
             visibleIds,
             setVisibleIds,
             moveUp,

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -7,19 +7,21 @@ import { handleKeyboardShortcut } from '../lib/keyboardShortcuts';
 
 export function useKeyboardShortcuts(onMigratePrompt: (bulletId: string) => void) {
     const { state, dispatch } = useStore();
-    const { focusedId, moveUp, moveDown, clearFocus } = useKeyboardFocus();
+    const { focusedId, moveUp, moveDown, clearFocus, setEditingId } = useKeyboardFocus();
     const { openNote } = useNoteEditor();
     const { requestConfirmation } = useConfirmation();
 
     // Use Refs to ensure the listener always has the latest state without re-binding constantly
     const stateRef = useRef(state);
     const focusedIdRef = useRef(focusedId);
+    const setEditingIdRef = useRef(setEditingId);
     const openNoteRef = useRef(openNote);
     const requestConfirmationRef = useRef(requestConfirmation);
     const onMigratePromptRef = useRef(onMigratePrompt);
 
     useEffect(() => { stateRef.current = state; }, [state]);
     useEffect(() => { focusedIdRef.current = focusedId; }, [focusedId]);
+    useEffect(() => { setEditingIdRef.current = setEditingId; }, [setEditingId]);
     useEffect(() => { openNoteRef.current = openNote; }, [openNote]);
     useEffect(() => { requestConfirmationRef.current = requestConfirmation; }, [requestConfirmation]);
     useEffect(() => { onMigratePromptRef.current = onMigratePrompt; }, [onMigratePrompt]);
@@ -37,6 +39,7 @@ export function useKeyboardShortcuts(onMigratePrompt: (bulletId: string) => void
                     moveUp,
                     moveDown,
                     clearFocus,
+                    setEditingId: (id) => setEditingIdRef.current(id),
                     dispatch,
                     openNote: (id) => openNoteRef.current(id),
                     onMigratePrompt: (id) => onMigratePromptRef.current(id),

--- a/src/lib/keyboardShortcuts.test.ts
+++ b/src/lib/keyboardShortcuts.test.ts
@@ -28,6 +28,7 @@ const createMockActions = () => ({
     moveUp: test.mock.fn(),
     moveDown: test.mock.fn(),
     clearFocus: test.mock.fn(),
+    setEditingId: test.mock.fn(),
     dispatch: test.mock.fn(),
     openNote: test.mock.fn(),
     onMigratePrompt: test.mock.fn(),
@@ -236,6 +237,24 @@ test('Action - d requests confirmation', (t) => {
         type: 'DELETE_BULLET',
         payload: { id: 'b1' }
     });
+});
+
+test('Action - e sets editing id', (t) => {
+    const bullet = createMockBullet('b1');
+    const actions = createMockActions();
+    const context: KeyboardShortcutContext = {
+        state: createMockState({ [bullet.id]: bullet }),
+        focusedId: bullet.id,
+        isInput: false,
+        actions
+    };
+    const event = { key: 'e', preventDefault: t.mock.fn() };
+
+    handleKeyboardShortcut(event, context);
+
+    assert.strictEqual(event.preventDefault.mock.callCount(), 1);
+    assert.strictEqual(actions.setEditingId.mock.callCount(), 1);
+    assert.strictEqual(actions.setEditingId.mock.calls[0].arguments[0], 'b1');
 });
 
 test('No action if not focused', (t) => {

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -8,6 +8,7 @@ export interface KeyboardShortcutContext {
         moveUp: () => void;
         moveDown: () => void;
         clearFocus: () => void;
+        setEditingId: (id: string | null) => void;
         dispatch: (action: Action) => void;
         openNote: (id: string) => void;
         onMigratePrompt: (id: string) => void;
@@ -32,7 +33,7 @@ export function handleKeyboardShortcut(
     context: KeyboardShortcutContext
 ) {
     const { state, focusedId, isInput, actions } = context;
-    const { moveUp, moveDown, clearFocus, dispatch, openNote, onMigratePrompt, requestConfirmation } = actions;
+    const { moveUp, moveDown, clearFocus, setEditingId, dispatch, openNote, onMigratePrompt, requestConfirmation } = actions;
 
     if (e.key === 'Escape') {
         e.preventDefault();
@@ -62,6 +63,11 @@ export function handleKeyboardShortcut(
     if (!bullet) return;
 
     switch (key) {
+        case 'e': {
+            e.preventDefault();
+            setEditingId(bullet.id);
+            break;
+        }
         case 'x': {
             e.preventDefault();
             const newState = bullet.state === 'completed' ? 'open' : 'completed';


### PR DESCRIPTION
Implemented inline editing for tasks to solve the issue where users couldn't edit tasks on mobile. The solution includes multiple ways to trigger editing (click, menu, keyboard) and ensures a consistent experience across devices.

Fixes #15

---
*PR created automatically by Jules for task [11937545179451845884](https://jules.google.com/task/11937545179451845884) started by @mrembert*