### PR TITLE
Reset project selector after task submission

### DIFF
--- a/src/components/BulletEditor.tsx
+++ b/src/components/BulletEditor.tsx
@@ -49,8 +49,7 @@ export function BulletEditor({ defaultDate, autoFocus = false }: { defaultDate?:
                 }
             });
             setContent('');
-            // Keep the selected collection sticky? Or reset?
-            // Let's keep it sticky for rapid entry.
+            setSelectedCollectionId('');
         }
     };
 


### PR DESCRIPTION
The project selector in the BulletEditor was remaining "sticky" after a task was submitted. This caused users to inadvertently assign the same project to the next task if they didn't manually reset it. This change adds a call to `setSelectedCollectionId('')` in the `handleSubmit` function to ensure the selector resets after each submission.

Fixes #18

---
*PR created automatically by Jules for task [14803329509829581703](https://jules.google.com/task/14803329509829581703) started by @mrembert*