### PR TITLE
Add CI/CD pipeline with GitHub Actions and Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,89 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: ${{ secrets.GCP_REGION }}
+  REPO_NAME: bullet-journal-repo
+  SERVICE_NAME: bullet-journal-app
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: npm test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_STATE_BUCKET_NAME }}" \
+            -backend-config="prefix=terraform/state"
+
+      - name: Terraform Apply (Infra - Registry)
+        working-directory: terraform
+        env:
+          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_region: ${{ secrets.GCP_REGION }}
+          TF_VAR_image_tag: "latest" # Placeholder, not used by registry resource
+          TF_VAR_repository_name: ${{ env.REPO_NAME }}
+          TF_VAR_service_name: ${{ env.SERVICE_NAME }}
+        run: |
+          terraform apply -auto-approve -target=google_artifact_registry_repository.default
+
+      - name: Configure Docker Auth
+        run: |
+          gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev
+
+      - name: Build and Push Docker Image
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE_URI="${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPO_NAME }}/${{ env.SERVICE_NAME }}:${IMAGE_TAG}"
+          docker build -t $IMAGE_URI .
+          docker push $IMAGE_URI
+
+      - name: Terraform Apply (Deploy Service)
+        working-directory: terraform
+        env:
+          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_region: ${{ secrets.GCP_REGION }}
+          TF_VAR_image_tag: ${{ github.sha }}
+          TF_VAR_repository_name: ${{ env.REPO_NAME }}
+          TF_VAR_service_name: ${{ env.SERVICE_NAME }}
+        run: |
+          terraform apply -auto-approve

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,64 +1,152 @@
-# Deploying to Google Cloud Run
+# Deployment Setup Instructions
 
-Follow these steps to deploy your Bullet Journal app to the web.
+This guide explains how to configure Google Cloud Platform (GCP) and GitHub Secrets to enable the automated deployment pipeline for this project.
 
-## 1. Prerequisites
-- **Google Cloud SDK** installed and initialized (`gcloud init`).
-- A **Billing-enabled** Google Cloud Project.
+## Prerequisites
 
-## 2. Prepare Environment
-Since this is a Vite app, environment variables (like your Firebase config) must be present **during the build**.
-1. Ensure your `.env.local` file contains all your `VITE_FIREBASE_...` keys.
-2. We have configured `.dockerignore` to included this file so the builder can see it.
+1.  A Google Cloud Project with billing enabled.
+2.  Google Cloud SDK (`gcloud`) installed and authenticated locally.
+3.  GitHub repository admin access.
 
-## 3. Enable Google Cloud Services
-Run this command once to enable the necessary APIs:
+## Step 1: Enable Required APIs
+
+Run the following commands to enable the necessary Google Cloud APIs:
+
 ```bash
-gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com
+gcloud services enable artifactregistry.googleapis.com \
+    run.googleapis.com \
+    iamcredentials.googleapis.com \
+    cloudresourcemanager.googleapis.com
 ```
 
-## 4. Build and Deploy
-Run these commands in your terminal:
+## Step 2: Create Terraform State Bucket
 
-### Step A: Setup Artifact Registry
-First, we need to create a repository to store our Docker images. Run this once:
+Terraform needs a remote backend to store the state of your infrastructure. We'll use a Google Cloud Storage (GCS) bucket for this.
+
+1.  Choose a unique name for your bucket (e.g., `bullet-journal-tf-state`).
+2.  Create the bucket:
+
 ```bash
-$PROJECT_ID = "bullet-journal-487001" 
-# IMPORTANT: Switch gcloud to use this project
-gcloud config set project $PROJECT_ID
+export BUCKET_NAME="your-unique-bucket-name"
+export LOCATION="us-central1" # Or your preferred region
 
-gcloud artifacts repositories create bullet-journal-repo `
-    --repository-format=docker `
-    --location=us-central1 `
-    --description="Bullet Journal App Repository"
+gcloud storage buckets create gs://$BUCKET_NAME --location=$LOCATION
 ```
 
-### Step B: Build and Push
-Now we build the image and push it to the new repository.
+3.  Enable versioning on the bucket (recommended for state files):
+
 ```bash
-# Submit the build to Cloud Build
-gcloud builds submit --tag us-central1-docker.pkg.dev/$PROJECT_ID/bullet-journal-repo/bullet-journal
+gcloud storage buckets update gs://$BUCKET_NAME --versioning
 ```
 
-### Step C: Deploy to Cloud Run
-Finally, deploy the image from the new repository.
+## Step 3: Configure Workload Identity Federation
+
+Workload Identity Federation allows GitHub Actions to authenticate to Google Cloud without storing long-lived service account keys.
+
+1.  **Set environment variables:**
+
 ```bash
-gcloud run deploy bullet-journal `
-  --image us-central1-docker.pkg.dev/$PROJECT_ID/bullet-journal-repo/bullet-journal `
-  --platform managed `
-  --region us-central1 `
-  --allow-unauthenticated
+export PROJECT_ID="your-project-id"
+export POOL_NAME="github-actions-pool"
+export PROVIDER_NAME="github-actions-provider"
+export SA_NAME="github-deploy-sa"
+export REPO="your-github-username/bullet-journal" # format: owner/repo
 ```
 
-## 5. Verify
-The command will output a **Service URL** (e.g., `https://bullet-journal-xyz-uc.a.run.app`).
-Click it to open your live app!
+2.  **Create the Workload Identity Pool:**
 
-> **Note**: If you see "Access Denied" or blank screens on the live site, ensure you have added the live URL to your **Firebase Console -> Authentication -> Settings -> Authorized Domains**.
+```bash
+gcloud iam workload-identity-pools create $POOL_NAME \
+    --project=$PROJECT_ID \
+    --location="global" \
+    --display-name="GitHub Actions Pool"
+```
 
-## 6. Security Note
-This deployment method is **secure** for the following reasons:
-1.  **Multi-Stage Build**: The `.env` file containing your keys is used **only** during the build step. It is **discarded** in the final Docker image. Your raw environment file is never shipped to the server.
-2.  **Public Keys**: The Firebase keys (API Key, Auth Domain, etc.) are designed to be public. It is safe for them to be embedded in your client-side JavaScript.
-3.  **Data Protection**: Even though your app is public (`allow-unauthenticated`), your **Data** is protected by the **Firestore Security Rules** we set up earlier. Only logged-in users can read/write their own data.
-4.  **No Server Secrets**: This architecture uses client-side auth. We are not storing any sensitive Service Account Keys on the server.
+3.  **Create the Workload Identity Provider:**
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc $PROVIDER_NAME \
+    --project=$PROJECT_ID \
+    --location="global" \
+    --workload-identity-pool=$POOL_NAME \
+    --display-name="GitHub Actions Provider" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+    --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+4.  **Create a Service Account for Deployment:**
+
+```bash
+gcloud iam service-accounts create $SA_NAME \
+    --display-name="GitHub Actions Deployment SA"
+```
+
+5.  **Grant Permissions to the Service Account:**
+
+The service account needs permissions to manage Artifact Registry, Cloud Run, and Storage (for Terraform state).
+
+```bash
+# Artifact Registry Admin
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/artifactregistry.admin"
+
+# Cloud Run Admin
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/run.admin"
+
+# Service Account User (to deploy Cloud Run services as this SA)
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountUser"
+
+# Storage Admin (for Terraform state bucket access)
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/storage.admin"
+```
+
+6.  **Allow GitHub Actions to Impersonate the Service Account:**
+
+```bash
+# Get the full pool ID
+export WORKLOAD_IDENTITY_POOL_ID=$(gcloud iam workload-identity-pools describe $POOL_NAME \
+    --project=$PROJECT_ID \
+    --location="global" \
+    --format="value(name)")
+
+# Bind the repository to the service account
+gcloud iam service-accounts add-iam-policy-binding "$SA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --project=$PROJECT_ID \
+    --role="roles/iam.workloadIdentityUser" \
+    --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_ID}/attribute.repository/${REPO}"
+```
+
+## Step 4: Configure GitHub Secrets
+
+Go to your GitHub repository -> **Settings** -> **Secrets and variables** -> **Actions** -> **New repository secret**.
+
+Add the following secrets:
+
+| Secret Name | Value | Description |
+| :--- | :--- | :--- |
+| `GCP_PROJECT_ID` | `your-project-id` | Your Google Cloud Project ID. |
+| `GCP_REGION` | `us-central1` | Region for resources (e.g., us-central1). |
+| `TF_STATE_BUCKET_NAME` | `your-unique-bucket-name` | Name of the GCS bucket created in Step 2. |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123456789/locations/global/workloadIdentityPools/...` | Full resource name of the provider. |
+| `GCP_SERVICE_ACCOUNT` | `github-deploy-sa@...` | Email of the service account created in Step 3. |
+
+**To find the Provider resource name:**
+
+```bash
+gcloud iam workload-identity-pools providers describe $PROVIDER_NAME \
+    --project=$PROJECT_ID \
+    --location="global" \
+    --workload-identity-pool=$POOL_NAME \
+    --format="value(name)"
+```
+
+## Step 5: Push to Main
+
+Once these secrets are set, any push to the `main` branch will trigger the workflow, provision infrastructure via Terraform, build the container, and deploy it to Cloud Run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM node:18-alpine as build
+FROM node:22-alpine as build
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --test --experimental-strip-types src/**/*.test.ts",
     "preview": "vite preview",
     "emulators": "firebase emulators:start --import=./firebase-data --export-on-exit",
     "dev:emulator": "concurrently \"npm run emulators\" \"npm run dev\""

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    # Bucket and prefix will be provided via CLI arguments or environment variables
+    # e.g., terraform init -backend-config="bucket=$TF_STATE_BUCKET_NAME" -backend-config="prefix=terraform/state"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Artifact Registry Repository
+resource "google_artifact_registry_repository" "default" {
+  location      = var.region
+  repository_id = var.repository_name
+  description   = "Docker repository for Bullet Journal App"
+  format        = "DOCKER"
+}
+
+# Cloud Run Service
+resource "google_cloud_run_service" "default" {
+  name     = var.service_name
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.repository_name}/${var.service_name}:${var.image_tag}"
+
+        resources {
+          limits = {
+            cpu    = "1000m"
+            memory = "512Mi"
+          }
+        }
+
+        ports {
+          container_port = 8080
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  depends_on = [google_artifact_registry_repository.default]
+}
+
+# IAM Policy to allow public access
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location    = google_cloud_run_service.default.location
+  project     = google_cloud_run_service.default.project
+  service     = google_cloud_run_service.default.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "service_url" {
+  value = google_cloud_run_service.default.status[0].url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  description = "The Google Cloud Project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The Google Cloud region to deploy to"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "image_tag" {
+  description = "The tag of the Docker image to deploy"
+  type        = string
+}
+
+variable "service_name" {
+  description = "The name of the Cloud Run service"
+  type        = string
+  default     = "bullet-journal-app"
+}
+
+variable "repository_name" {
+  description = "The name of the Artifact Registry repository"
+  type        = string
+  default     = "bullet-journal-repo"
+}


### PR DESCRIPTION
Added a GitHub Actions workflow to deploy the app to Google Cloud Run.
- Created `DEPLOY.md` with setup instructions for Workload Identity Federation and GCS state backend.
- Added `terraform/` configuration to provision Artifact Registry and Cloud Run service.
- Updated `Dockerfile` to use `node:22-alpine` to support the native test runner.
- Added `test` script to `package.json` using `node --test`.
- Created `.github/workflows/deploy.yml` for automated testing and deployment.

---
*PR created automatically by Jules for task [5131660444318373822](https://jules.google.com/task/5131660444318373822) started by @mrembert*