### PR TITLE
Fix alignment of project labels and handle long names with truncation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "firebase-tools": "^15.5.1",
         "globals": "^16.5.0",
+        "playwright": "^1.58.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
@@ -12195,6 +12196,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "firebase-tools": "^15.5.1",
     "globals": "^16.5.0",
+    "playwright": "^1.58.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/src/components/SortableProjectItem.tsx
+++ b/src/components/SortableProjectItem.tsx
@@ -34,9 +34,19 @@ export function SortableProjectItem({ collection, isActive, onSelect, onToggleAr
                 <button
                     onClick={onSelect}
                     className={`btn ${isActive ? 'btn-primary' : 'btn-ghost'}`}
-                    style={{ justifyContent: 'flex-start', flex: 1, fontSize: '0.9rem', cursor: 'grab' }}
+                    style={{ justifyContent: 'flex-start', flex: 1, fontSize: '0.9rem', cursor: 'grab', minWidth: 0, textAlign: 'left' }}
+                    title={collection.title}
                 >
-                    <List size={16} /> {collection.title}
+                    <List size={16} style={{ flexShrink: 0 }} />
+                    <span style={{
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        flex: 1,
+                        minWidth: 0
+                    }}>
+                        {collection.title}
+                    </span>
                 </button>
                 <div className="project-actions" style={{ display: 'flex' }}>
                     <button


### PR DESCRIPTION
Improved the project list item rendering in the sidebar. Previously, long project names would wrap and potentially center-align due to default button styles, causing visual inconsistency.

Changes:
- Enforced single-line display with truncation (`...`) for long project names.
- Explicitly left-aligned the project label text.
- Added a tooltip (via `title` attribute) to display the full project name on hover.
- Adjusted flexbox properties to ensure the icon remains fixed while the text truncates properly.


---
*PR created automatically by Jules for task [6950521842292542965](https://jules.google.com/task/6950521842292542965) started by @mrembert*