### PR TITLE
Fix keyboard focus for migration menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -467,28 +467,13 @@ function App() {
       )}
 
       {migratingBulletId && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          zIndex: 1000,
-          backgroundColor: 'rgba(0,0,0,0.2)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center'
-        }} onClick={() => setMigratingBulletId(null)}>
-          <div style={{ position: 'relative' }} onClick={e => e.stopPropagation()}>
-            <MigrationPicker
-              onSelectDate={(date) => {
-                dispatch({ type: 'MIGRATE_BULLET', payload: { id: migratingBulletId, targetDate: date } });
-                setMigratingBulletId(null);
-              }}
-              onCancel={() => setMigratingBulletId(null)}
-            />
-          </div>
-        </div>
+        <MigrationPicker
+          onSelectDate={(date) => {
+            dispatch({ type: 'MIGRATE_BULLET', payload: { id: migratingBulletId, targetDate: date } });
+            setMigratingBulletId(null);
+          }}
+          onCancel={() => setMigratingBulletId(null)}
+        />
       )}
 
       {movingBulletId && (

--- a/src/lib/database.logic.ts
+++ b/src/lib/database.logic.ts
@@ -1,10 +1,6 @@
 
 import type {
-    Firestore
-} from 'firebase/firestore';
-import type { AppState, Bullet, Collection, Action } from '../types';
-
-import {
+    Firestore,
     collection,
     doc,
     onSnapshot,
@@ -12,6 +8,7 @@ import {
     deleteDoc,
     updateDoc
 } from 'firebase/firestore';
+import type { AppState, Bullet, Collection, Action } from '../types';
 
 export interface DatabaseDeps {
     collection: typeof collection;


### PR DESCRIPTION
The keyboard shortcut 'm' for migrating tasks was opening a menu that didn't capture focus, causing arrow key navigation to still affect the underlying task list. 

This PR fixes the issue by:
1. Refactoring `MigrationPicker` to use `createPortal`, rendering it outside the main DOM tree to avoid positioning issues.
2. Using the `usePopupNavigation` hook in `MigrationPicker` to handle arrow key navigation within the menu.
3. Adding the `picker-overlay` class to the `MigrationPicker` backdrop, which allows the `useKeyboardShortcuts` hook to correctly detect the open modal and disable background shortcuts.
4. Cleaning up redundant backdrop logic in `App.tsx`.
5. Updating `src/lib/database.logic.ts` to use `import type` for Firestore, fixing test failures in the Node environment.
6. Refactoring the custom date input in `MigrationPicker` to use `useRef` instead of `document.getElementById` for better React idiomaticity.

Fixes #26

---
*PR created automatically by Jules for task [17752613979088756742](https://jules.google.com/task/17752613979088756742) started by @mrembert*