### PR TITLE
Fix migrated tasks visibility and note synchronization

### DIFF
--- a/src/components/BulletItem.tsx
+++ b/src/components/BulletItem.tsx
@@ -58,7 +58,7 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
     const toggleState = () => {
         if (bullet.state === 'open') {
             dispatch({ type: 'UPDATE_BULLET', payload: { id: bullet.id, state: 'completed' } });
-        } else if (bullet.state === 'completed') {
+        } else if (bullet.state === 'completed' || bullet.state === 'migrated') {
             dispatch({ type: 'UPDATE_BULLET', payload: { id: bullet.id, state: 'open' } });
         }
     };


### PR DESCRIPTION
This change addresses the issue where migrated tasks remained visible but un-interactable in the Daily Log. It adds a toggle to hide/show migrated tasks, allows reverting migrated tasks to open, and synchronizes parent note content when a task embedded in a note is migrated.

Key Improvements:
- Visibility Toggle: Users can now hide or show migrated tasks in Daily and Week views.
- Note Sync: Tasks embedded in notes now maintain their connection to the active task even after migration.
- Revert Migration: Migrated tasks can be toggled back to 'open' state easily.
- Tested: New unit tests verify the synchronization logic, and all regression tests passed.

Fixes #25

---
*PR created automatically by Jules for task [16338710410723617350](https://jules.google.com/task/16338710410723617350) started by @mrembert*