### PR TITLE
⚡ Optimize StoreProvider context value with useMemo

### DIFF
--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, useCallback, useMemo } from 'react';
 import type { AppState, Action } from './types';
 import { useAuth } from './contexts/AuthContext';
 import { performActionInFirestore, subscribeToUserData } from './lib/database';
@@ -34,7 +34,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
 
     // 3. Dispatch Wrapper
     // This intercepts actions, generates IDs if needed, updates local state, AND calls Firestore
-    const dispatch = async (action: Action) => {
+    const dispatch = useCallback(async (action: Action) => {
         // Enforce ID generation for creations
         let enhancedAction: any = { ...action };
 
@@ -59,10 +59,12 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                 performActionInFirestore(user.uid, enhancedAction, state);
             }
         }
-    };
+    }, [state, user]);
+
+    const value = useMemo(() => ({ state, dispatch }), [state, dispatch]);
 
     return (
-        <StoreContext.Provider value={{ state, dispatch }}>
+        <StoreContext.Provider value={value}>
             {children}
         </StoreContext.Provider>
     );


### PR DESCRIPTION
Memoized `dispatch` and context `value` to prevent unnecessary re-renders of consumers when `StoreProvider` re-renders but state is unchanged.

💡 **What:**
- Wrapped `dispatch` in `useCallback` with dependencies `[state, user]`.
- Wrapped context `value` in `useMemo` with dependencies `[state, dispatch]`.

🎯 **Why:**
- `StoreProvider` re-renders whenever `AuthProvider` updates (e.g., authorization check).
- Previously, this caused `dispatch` and `value` to be recreated, forcing *all* context consumers (the entire app) to re-render.
- Now, if `state` and `user` are stable, `value` remains stable, avoiding the cascade.

📊 **Measured Improvement:**
- Verified by code inspection and ensuring existing tests pass.
- Eliminates context updates on parent re-renders when data is stable.

---
*PR created automatically by Jules for task [12322032634015503470](https://jules.google.com/task/12322032634015503470) started by @mrembert*