### PR TITLE
Add date filtering and project exclusion to export feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { MigrationPicker } from './components/MigrationPicker';
 import { ProjectPicker } from './components/ProjectPicker';
 import { ShortcutsOverlay } from './components/ShortcutsOverlay';
+import { ExportDialog } from './components/ExportDialog';
 import { Keyboard } from 'lucide-react';
 import {
   DndContext,
@@ -50,6 +51,7 @@ function App() {
   const [migratingBulletId, setMigratingBulletId] = useState<string | null>(null);
   const [movingBulletId, setMovingBulletId] = useState<string | null>(null);
   const [showShortcuts, setShowShortcuts] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
 
   const closeSidebar = () => setSidebarOpen(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -168,17 +170,6 @@ function App() {
       setNewCollectionTitle('');
       setIsCreatingCollection(false);
     }
-  };
-
-  const handleExport = () => {
-    const dataStr = JSON.stringify(state, null, 2);
-    const blob = new Blob([dataStr], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `bujo-backup-${new Date().toISOString().split('T')[0]}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
   };
 
   const handleImport = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -402,7 +393,7 @@ function App() {
 
         <div style={{ marginTop: 'auto', paddingTop: '1rem', borderTop: '1px solid hsl(var(--color-text-secondary) / 0.1)' }}>
           <input type="file" ref={fileInputRef} onChange={handleImport} style={{ display: 'none' }} accept=".json" />
-          <button onClick={handleExport} className="btn btn-ghost" style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}>
+          <button onClick={() => setShowExportDialog(true)} className="btn btn-ghost" style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}>
             <Download size={16} /> Export Backup
           </button>
           <button onClick={() => fileInputRef.current?.click()} className="btn btn-ghost" style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}>
@@ -490,6 +481,10 @@ function App() {
 
       {showShortcuts && (
         <ShortcutsOverlay onClose={() => setShowShortcuts(false)} />
+      )}
+
+      {showExportDialog && (
+        <ExportDialog onClose={() => setShowExportDialog(false)} />
       )}
     </div>
   );

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -1,0 +1,268 @@
+
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useStore } from '../store';
+import { filterStateForExport, type ExportOptions } from '../lib/exportUtils';
+import { X, Check, Download, Calendar, Folder } from 'lucide-react';
+
+interface ExportDialogProps {
+    onClose: () => void;
+}
+
+export function ExportDialog({ onClose }: ExportDialogProps) {
+    const { state } = useStore();
+    const [dateRange, setDateRange] = useState<ExportOptions['dateRange']>('all');
+    // Track excluded projects (initially empty = include all)
+    const [excludedProjects, setExcludedProjects] = useState<Set<string>>(new Set());
+    const [isExporting, setIsExporting] = useState(false);
+
+    // Get all projects sorted by order or creation
+    const projects = Object.values(state.collections)
+        .filter(c => c.type === 'project')
+        .sort((a, b) => {
+            if (a.order !== undefined && b.order !== undefined) {
+                return a.order - b.order;
+            }
+            return b.createdAt - a.createdAt;
+        });
+
+    const toggleProject = (id: string) => {
+        const newExcluded = new Set(excludedProjects);
+        if (newExcluded.has(id)) {
+            newExcluded.delete(id);
+        } else {
+            newExcluded.add(id);
+        }
+        setExcludedProjects(newExcluded);
+    };
+
+    const handleExport = async () => {
+        setIsExporting(true);
+        try {
+            const filteredState = await filterStateForExport(state, {
+                dateRange,
+                excludedCollectionIds: Array.from(excludedProjects)
+            });
+
+            const dataStr = JSON.stringify(filteredState, null, 2);
+            const blob = new Blob([dataStr], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `bujo-backup-${new Date().toISOString().split('T')[0]}.json`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+
+            onClose();
+        } catch (error) {
+            console.error('Export failed', error);
+            alert('Export failed. See console for details.');
+        } finally {
+            setIsExporting(false);
+        }
+    };
+
+    // Style helpers
+    const sectionTitleStyle = {
+        fontSize: '0.85rem',
+        fontWeight: 600,
+        textTransform: 'uppercase' as const,
+        letterSpacing: '0.05em',
+        color: 'hsl(var(--color-text-secondary))',
+        marginBottom: '0.75rem',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem'
+    };
+
+    const radioLabelStyle = (active: boolean) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.5rem 0.75rem',
+        borderRadius: 'var(--radius-sm)',
+        cursor: 'pointer',
+        backgroundColor: active ? 'hsl(var(--color-accent) / 0.1)' : 'transparent',
+        color: active ? 'hsl(var(--color-accent))' : 'hsl(var(--color-text-primary))',
+        border: active ? '1px solid hsl(var(--color-accent) / 0.3)' : '1px solid transparent',
+        transition: 'all 0.2s ease',
+        fontSize: '0.9rem'
+    });
+
+    return createPortal(
+        <div className="picker-overlay" onClick={onClose}>
+            <div onClick={e => e.stopPropagation()}>
+                <div
+                    className="picker-panel"
+                    style={{ width: '500px', maxWidth: '90vw', padding: '1.5rem' }}
+                >
+                    <div style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        marginBottom: '1.5rem',
+                        borderBottom: '1px solid hsl(var(--color-text-secondary) / 0.1)',
+                        paddingBottom: '1rem'
+                    }}>
+                        <h2 style={{ fontSize: '1.25rem', fontWeight: 700, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                            <Download size={20} /> Export Backup
+                        </h2>
+                        <button onClick={onClose} style={{ border: 'none', background: 'transparent', cursor: 'pointer', color: 'hsl(var(--color-text-secondary))' }}>
+                            <X size={20} />
+                        </button>
+                    </div>
+
+                    {/* Date Range Selection */}
+                    <div style={{ marginBottom: '2rem' }}>
+                        <div style={sectionTitleStyle}>
+                            <Calendar size={14} /> Date Range
+                        </div>
+                        <div style={{ display: 'grid', gap: '0.5rem' }}>
+                            <label style={radioLabelStyle(dateRange === 'all')}>
+                                <input
+                                    type="radio"
+                                    name="dateRange"
+                                    value="all"
+                                    checked={dateRange === 'all'}
+                                    onChange={() => setDateRange('all')}
+                                    style={{ accentColor: 'hsl(var(--color-accent))' }}
+                                />
+                                All Time
+                            </label>
+                            <label style={radioLabelStyle(dateRange === 'this-week')}>
+                                <input
+                                    type="radio"
+                                    name="dateRange"
+                                    value="this-week"
+                                    checked={dateRange === 'this-week'}
+                                    onChange={() => setDateRange('this-week')}
+                                    style={{ accentColor: 'hsl(var(--color-accent))' }}
+                                />
+                                This Week (Mon - Sun)
+                            </label>
+                            <label style={radioLabelStyle(dateRange === 'past-30-days')}>
+                                <input
+                                    type="radio"
+                                    name="dateRange"
+                                    value="past-30-days"
+                                    checked={dateRange === 'past-30-days'}
+                                    onChange={() => setDateRange('past-30-days')}
+                                    style={{ accentColor: 'hsl(var(--color-accent))' }}
+                                />
+                                Past 30 Days
+                            </label>
+                        </div>
+                        <p style={{ fontSize: '0.8rem', color: 'hsl(var(--color-text-secondary))', marginTop: '0.5rem', marginLeft: '0.5rem' }}>
+                            * Undated items in Open Tasks/Backlog are always included.
+                        </p>
+                    </div>
+
+                    {/* Project Selection */}
+                    <div style={{ marginBottom: '2rem' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+                            <div style={{ ...sectionTitleStyle, marginBottom: 0 }}>
+                                <Folder size={14} /> Projects
+                            </div>
+                            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                                <button
+                                    className="btn-ghost"
+                                    style={{ fontSize: '0.75rem', padding: '0.2rem 0.5rem', height: 'auto' }}
+                                    onClick={() => setExcludedProjects(new Set())}
+                                >
+                                    Select All
+                                </button>
+                                <button
+                                    className="btn-ghost"
+                                    style={{ fontSize: '0.75rem', padding: '0.2rem 0.5rem', height: 'auto' }}
+                                    onClick={() => setExcludedProjects(new Set(projects.map(p => p.id)))}
+                                >
+                                    Deselect All
+                                </button>
+                            </div>
+                        </div>
+
+                        <div style={{
+                            maxHeight: '200px',
+                            overflowY: 'auto',
+                            border: '1px solid hsl(var(--color-text-secondary) / 0.2)',
+                            borderRadius: 'var(--radius-sm)',
+                            padding: '0.5rem'
+                        }}>
+                            {projects.length === 0 ? (
+                                <div style={{ padding: '1rem', textAlign: 'center', color: 'hsl(var(--color-text-secondary))', fontSize: '0.9rem' }}>
+                                    No projects found.
+                                </div>
+                            ) : (
+                                projects.map(project => {
+                                    const isIncluded = !excludedProjects.has(project.id);
+                                    return (
+                                        <label
+                                            key={project.id}
+                                            style={{
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '0.75rem',
+                                                padding: '0.5rem',
+                                                cursor: 'pointer',
+                                                borderRadius: 'var(--radius-sm)',
+                                                transition: 'background-color 0.2s',
+                                            }}
+                                            className="project-checkbox-item"
+                                            onMouseEnter={e => e.currentTarget.style.backgroundColor = 'hsl(var(--color-bg-primary))'}
+                                            onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}
+                                        >
+                                            <div style={{
+                                                width: '18px',
+                                                height: '18px',
+                                                border: isIncluded ? 'none' : '2px solid hsl(var(--color-text-secondary) / 0.5)',
+                                                borderRadius: '4px',
+                                                backgroundColor: isIncluded ? 'hsl(var(--color-accent))' : 'transparent',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                                transition: 'all 0.2s'
+                                            }}>
+                                                {isIncluded && <Check size={12} color="white" />}
+                                            </div>
+                                            <input
+                                                type="checkbox"
+                                                checked={isIncluded}
+                                                onChange={() => toggleProject(project.id)}
+                                                style={{ display: 'none' }}
+                                            />
+                                            <span style={{ fontSize: '0.9rem', color: isIncluded ? 'hsl(var(--color-text-primary))' : 'hsl(var(--color-text-secondary))' }}>
+                                                {project.title}
+                                            </span>
+                                        </label>
+                                    );
+                                })
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Footer actions */}
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.75rem' }}>
+                        <button
+                            onClick={onClose}
+                            className="btn btn-ghost"
+                            disabled={isExporting}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleExport}
+                            className="btn btn-primary"
+                            disabled={isExporting}
+                            style={{ minWidth: '100px', justifyContent: 'center' }}
+                        >
+                            {isExporting ? 'Exporting...' : 'Export'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>,
+        document.body
+    );
+}

--- a/src/lib/exportUtils.test.ts
+++ b/src/lib/exportUtils.test.ts
@@ -1,0 +1,157 @@
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { filterStateForExport, type ExportOptions, type DateLib } from './exportUtils.ts';
+import type { AppState, Bullet, Collection } from '../types.ts';
+
+// Fixed "Today" for testing: Friday, Oct 27, 2023
+const fixedToday = new Date('2023-10-27T00:00:00Z');
+
+const mockDateLib: DateLib = {
+    parseISO: (s: string) => new Date(s),
+    startOfDay: (d: Date) => {
+        // Always return fixed today for consistency in this test context
+        return new Date(fixedToday);
+    },
+    subDays: (d: Date, amount: number) => {
+        const n = new Date(d);
+        n.setDate(n.getDate() - amount);
+        return n;
+    },
+    startOfWeek: (d: Date, options?: { weekStartsOn: 1 }) => {
+        // Assuming d is fixedToday (Friday)
+        // Monday was 4 days ago
+        const n = new Date(d);
+        n.setDate(n.getDate() - 4);
+        return n;
+    },
+    endOfWeek: (d: Date, options?: { weekStartsOn: 1 }) => {
+        // Assuming d is fixedToday (Friday)
+        // Sunday is 2 days ahead
+        const n = new Date(d);
+        n.setDate(n.getDate() + 2);
+        return n;
+    },
+    isWithinInterval: (date: Date, interval: { start: Date, end: Date }) => {
+        return date.getTime() >= interval.start.getTime() && date.getTime() <= interval.end.getTime();
+    }
+};
+
+describe('filterStateForExport', () => {
+    // Helper to create a minimal AppState
+    const createMockState = (bullets: Record<string, Bullet>, collections: Record<string, Collection>): AppState => ({
+        bullets,
+        collections,
+        view: { mode: 'daily', date: '2023-01-01' },
+        preferences: { groupByProject: false, showCompleted: true, showMigrated: false, sortByType: false }
+    });
+
+    const todayStr = '2023-10-27T00:00:00Z';
+    const yesterdayStr = '2023-10-26T00:00:00Z';
+    const lastWeekStr = '2023-10-20T00:00:00Z'; // Outside "this week" (Mon 23 - Sun 29)
+    const longAgoStr = '2023-08-27T00:00:00Z';
+
+    // Create some mock collections
+    const collections: Record<string, Collection> = {
+        'proj1': { id: 'proj1', title: 'Project 1', type: 'project', createdAt: 123 },
+        'proj2': { id: 'proj2', title: 'Project 2', type: 'project', createdAt: 123 },
+    };
+
+    // Create some mock bullets
+    const bullets: Record<string, Bullet> = {
+        'b1': { id: 'b1', content: 'Task 1', type: 'task', state: 'open', date: todayStr, collectionId: 'proj1', order: 1, createdAt: 1, updatedAt: 1 },
+        'b2': { id: 'b2', content: 'Task 2', type: 'task', state: 'open', date: yesterdayStr, collectionId: 'proj2', order: 2, createdAt: 1, updatedAt: 1 },
+        'b3': { id: 'b3', content: 'Task 3', type: 'task', state: 'open', date: lastWeekStr, collectionId: null, order: 3, createdAt: 1, updatedAt: 1 },
+        'b4': { id: 'b4', content: 'Task 4', type: 'task', state: 'open', date: longAgoStr, collectionId: 'proj1', order: 4, createdAt: 1, updatedAt: 1 },
+        'b5': { id: 'b5', content: 'Undated Task', type: 'task', state: 'open', date: null, collectionId: 'proj1', order: 5, createdAt: 1, updatedAt: 1 },
+        'b6': { id: 'b6', content: 'Undated Task 2', type: 'task', state: 'open', date: undefined, collectionId: 'proj2', order: 6, createdAt: 1, updatedAt: 1 },
+    };
+
+    const state = createMockState(bullets, collections);
+
+    it('should exclude specified projects and their bullets', async () => {
+        const options: ExportOptions = {
+            dateRange: 'all',
+            excludedCollectionIds: ['proj1']
+        };
+
+        const result = await filterStateForExport(state, options, mockDateLib);
+
+        // Check Collections
+        assert.ok(!result.collections['proj1'], 'proj1 should be removed');
+        assert.ok(result.collections['proj2'], 'proj2 should be kept');
+
+        // Check Bullets
+        assert.ok(!result.bullets['b1'], 'b1 (proj1) should be removed');
+        assert.ok(result.bullets['b2'], 'b2 (proj2) should be kept');
+        assert.ok(result.bullets['b3'], 'b3 (no project) should be kept');
+        assert.ok(!result.bullets['b4'], 'b4 (proj1) should be removed');
+        assert.ok(!result.bullets['b5'], 'b5 (undated, proj1) should be removed because project excluded');
+        assert.ok(result.bullets['b6'], 'b6 (undated, proj2) should be kept');
+    });
+
+    it('should filter by date: past-30-days', async () => {
+        const options: ExportOptions = {
+            dateRange: 'past-30-days',
+            excludedCollectionIds: []
+        };
+
+        const result = await filterStateForExport(state, options, mockDateLib);
+
+        // Logic check:
+        // today is 2023-10-27.
+        // subDays(today, 29) -> 2023-09-28.
+        // Interval: [2023-09-28, 2023-10-27].
+
+        // b1 (today 10-27): keep
+        assert.ok(result.bullets['b1'], 'b1 (today) should be kept');
+        // b2 (yesterday 10-26): keep
+        assert.ok(result.bullets['b2'], 'b2 (yesterday) should be kept');
+        // b3 (10-20): keep (within 30 days)
+        assert.ok(result.bullets['b3'], 'b3 (last week) should be kept');
+        // b4 (08-27): exclude (way before 09-28)
+        assert.ok(!result.bullets['b4'], 'b4 (60 days ago) should be removed');
+        // b5 (undated): keep
+        assert.ok(result.bullets['b5'], 'b5 (undated) should be kept');
+    });
+
+    it('should filter by date: this-week', async () => {
+        const options: ExportOptions = {
+            dateRange: 'this-week',
+            excludedCollectionIds: []
+        };
+
+        const result = await filterStateForExport(state, options, mockDateLib);
+
+        // Week: Mon Oct 23 - Sun Oct 29
+
+        // b1 (Fri 10-27): keep
+        assert.ok(result.bullets['b1'], 'b1 (today/Fri) should be kept');
+        // b2 (Thu 10-26): keep
+        assert.ok(result.bullets['b2'], 'b2 (Thu) should be kept');
+        // b3 (Fri 10-20): exclude (last week)
+        assert.ok(!result.bullets['b3'], 'b3 (last week) should be removed');
+        // b4 (08-27): exclude
+        assert.ok(!result.bullets['b4'], 'b4 (60 days ago) should be removed');
+        // b5 (undated): keep
+        assert.ok(result.bullets['b5'], 'b5 (undated) should be kept');
+    });
+
+    it('should combine project exclusion and date filtering', async () => {
+        const options: ExportOptions = {
+            dateRange: 'past-30-days',
+            excludedCollectionIds: ['proj1']
+        };
+
+        const result = await filterStateForExport(state, options, mockDateLib);
+
+        // b1 (today, proj1): exclude (project)
+        assert.ok(!result.bullets['b1']);
+        // b2 (yesterday, proj2): keep
+        assert.ok(result.bullets['b2']);
+        // b4 (60 days ago, proj1): exclude (project & date)
+        assert.ok(!result.bullets['b4']);
+        // b5 (undated, proj1): exclude (project)
+        assert.ok(!result.bullets['b5']);
+    });
+});

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -1,0 +1,113 @@
+
+import type { AppState, Bullet, Collection } from '../types';
+
+export interface ExportOptions {
+    dateRange: 'all' | 'this-week' | 'past-30-days';
+    excludedCollectionIds: string[];
+}
+
+export interface DateLib {
+    parseISO: (dateString: string) => Date;
+    isWithinInterval: (date: Date, interval: { start: Date, end: Date }) => boolean;
+    startOfWeek: (date: Date, options?: { weekStartsOn: 1 }) => Date;
+    endOfWeek: (date: Date, options?: { weekStartsOn: 1 }) => Date;
+    subDays: (date: Date, amount: number) => Date;
+    startOfDay: (date: Date) => Date;
+}
+
+/**
+ * Filters the application state for export based on the provided options.
+ *
+ * Requirements:
+ * 1. Project Exclusion:
+ *    - Remove excluded projects (Collection) from the collections map.
+ *    - Remove all bullets belonging to an excluded project.
+ * 2. Date Filtering:
+ *    - 'all': Include all remaining bullets.
+ *    - 'this-week': Include bullets within the current calendar week (Mon-Sun).
+ *    - 'past-30-days': Include bullets within the last 30 days (inclusive of today).
+ *    - ALWAYS include undated bullets (where bullet.date is null/undefined).
+ *
+ * @param state The full AppState.
+ * @param options The export options.
+ * @param dateLib Optional dependency injection for date library (defaults to date-fns).
+ * @returns A new AppState object containing only the filtered data.
+ */
+export async function filterStateForExport(
+    state: AppState,
+    options: ExportOptions,
+    dateLib?: DateLib
+): Promise<AppState> {
+    const { dateRange, excludedCollectionIds } = options;
+
+    // Load date-fns dynamically if not provided
+    // This allows testing without node_modules by injecting a mock
+    const dateFns = dateLib || (await import('date-fns') as unknown as DateLib);
+    const { parseISO, isWithinInterval, startOfWeek, endOfWeek, subDays, startOfDay } = dateFns;
+
+    const now = new Date();
+    const today = startOfDay(now);
+
+    // Date Range Calculations
+    let dateFilterFn: ((dateStr: string) => boolean) | null = null;
+
+    if (dateRange === 'this-week') {
+        const start = startOfWeek(today, { weekStartsOn: 1 }); // Monday
+        const end = endOfWeek(today, { weekStartsOn: 1 }); // Sunday
+        dateFilterFn = (dateStr: string) => {
+            const date = parseISO(dateStr);
+            return isWithinInterval(date, { start, end });
+        };
+    } else if (dateRange === 'past-30-days') {
+        const start = subDays(today, 29); // 29 days ago + today = 30 days
+        const end = today;
+        dateFilterFn = (dateStr: string) => {
+            const date = parseISO(dateStr);
+            // Comparing dates using isWithinInterval is safer for consistency
+            return isWithinInterval(date, { start, end });
+        };
+    }
+
+    // 1. Filter Collections
+    // Create a new collections object excluding the selected IDs
+    const filteredCollections: Record<string, Collection> = {};
+    Object.entries(state.collections).forEach(([id, collection]) => {
+        if (!excludedCollectionIds.includes(id)) {
+            filteredCollections[id] = collection;
+        }
+    });
+
+    // 2. Filter Bullets
+    const filteredBullets: Record<string, Bullet> = {};
+    Object.entries(state.bullets).forEach(([id, bullet]) => {
+        // Check Project Exclusion
+        // If the bullet belongs to a collection, and that collection is excluded, skip it.
+        if (bullet.collectionId && excludedCollectionIds.includes(bullet.collectionId)) {
+            return;
+        }
+
+        // Check Date Filtering
+        // Always include undated bullets
+        if (!bullet.date) {
+            filteredBullets[id] = bullet;
+            return;
+        }
+
+        // If dateRange is 'all', include it (unless excluded by project above)
+        if (dateRange === 'all') {
+            filteredBullets[id] = bullet;
+            return;
+        }
+
+        // Apply specific date filter
+        if (dateFilterFn && dateFilterFn(bullet.date)) {
+            filteredBullets[id] = bullet;
+        }
+    });
+
+    return {
+        ...state,
+        collections: filteredCollections,
+        bullets: filteredBullets,
+    };
+}


### PR DESCRIPTION
Replaces the immediate export download with a configuration dialog.
- Allows filtering by date range: "All Time", "This Week" (Mon-Sun), "Past 30 Days" (rolling).
- Always includes undated items in open/backlog.
- Allows excluding specific projects from the export.
- Implements filtering logic in 'src/lib/exportUtils.ts' with unit tests using 'node:test'.
- Uses dependency injection for date library to support testing in restricted environments.

---
*PR created automatically by Jules for task [17343568338945883519](https://jules.google.com/task/17343568338945883519) started by @mrembert*