### PR TITLE
Fix TypeScript error in storeReducer.ts

### DIFF
--- a/src/storeReducer.ts
+++ b/src/storeReducer.ts
@@ -1,4 +1,4 @@
-import type { AppState, Bullet, Action } from './types';
+import type { AppState, Bullet, Action, BulletState } from './types';
 import { generateUUID, getTodayDate } from './lib/utils.ts';
 
 
@@ -112,12 +112,12 @@ export function reducer(state: AppState, action: Action): AppState {
 
             const nextBullets = {
                 ...state.bullets,
-                [oldBullet.id]: { ...oldBullet, state: 'migrated', updatedAt: now },
+                [oldBullet.id]: { ...oldBullet, state: 'migrated' as BulletState, updatedAt: now },
                 [newId]: {
                     ...oldBullet,
                     id: newId,
                     date: action.payload.targetDate,
-                    state: 'open',
+                    state: 'open' as BulletState,
                     order: now,
                     createdAt: now,
                     updatedAt: now,


### PR DESCRIPTION
Fixed a TypeScript build error where `state` properties in `MIGRATE_BULLET` were inferred as `string` instead of `BulletState`.

---
*PR created automatically by Jules for task [14364971605864812294](https://jules.google.com/task/14364971605864812294) started by @mrembert*