### PR TITLE
Implement single-level Undo for task operations

### DIFF
--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,66 @@
+import { createContext, useContext, useState, useRef, useCallback, useMemo, type ReactNode } from 'react';
+
+interface ToastContextType {
+    showToast: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useToast() {
+    const context = useContext(ToastContext);
+    if (!context) {
+        throw new Error('useToast must be used within a ToastProvider');
+    }
+    return context;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+    const [message, setMessage] = useState<string | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const showToast = useCallback((msg: string) => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+        setMessage(msg);
+        timeoutRef.current = setTimeout(() => {
+            setMessage(null);
+            timeoutRef.current = null;
+        }, 3000);
+    }, []);
+
+    const value = useMemo(() => ({ showToast }), [showToast]);
+
+    return (
+        <ToastContext.Provider value={value}>
+            {children}
+            {message && (
+                <div style={{
+                    position: 'fixed',
+                    bottom: '2rem',
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    backgroundColor: 'hsl(var(--color-bg-secondary))',
+                    color: 'hsl(var(--color-text-primary))',
+                    padding: '0.75rem 1.5rem',
+                    borderRadius: 'var(--radius-md)',
+                    boxShadow: 'var(--shadow-lg)',
+                    border: '1px solid hsl(var(--color-text-secondary) / 0.2)',
+                    zIndex: 2000,
+                    fontWeight: 500,
+                    animation: 'fadeIn 0.2s ease-out',
+                    pointerEvents: 'none' // Allow clicking through if needed, though mostly unrelated
+                }}>
+                    {message}
+                </div>
+            )}
+            <style>{`
+                @keyframes fadeIn {
+                    from { opacity: 0; transform: translate(-50%, 10px); }
+                    to { opacity: 1; transform: translate(-50%, 0); }
+                }
+            `}</style>
+        </ToastContext.Provider>
+    );
+}

--- a/src/lib/database.logic.ts
+++ b/src/lib/database.logic.ts
@@ -101,6 +101,18 @@ export async function performActionInFirestoreLogic(
                 await deps.deleteDoc(deps.doc(usersRef, 'bullets', action.payload.id));
                 break;
             }
+            case 'RESTORE_BULLET': {
+                const { id, ...data } = action.payload;
+                const cleanData = Object.fromEntries(
+                    Object.entries(data).filter(([, v]) => v !== undefined)
+                );
+                await deps.setDoc(deps.doc(usersRef, 'bullets', id), {
+                    ...cleanData,
+                    id,
+                    updatedAt: Date.now()
+                });
+                break;
+            }
             case 'MIGRATE_BULLET': {
                 const bullet = currentState.bullets[action.payload.id];
                 if (!bullet) return;

--- a/src/lib/keyboardShortcuts.test.ts
+++ b/src/lib/keyboardShortcuts.test.ts
@@ -273,6 +273,59 @@ test('No action if not focused', (t) => {
     assert.strictEqual(actions.dispatch.mock.callCount(), 0);
 });
 
+test('Keyboard Shortcuts - Ctrl+Z dispatches UNDO', (t) => {
+    const actions = createMockActions();
+    const context: KeyboardShortcutContext = {
+        state: createMockState(),
+        focusedId: null,
+        isInput: false,
+        actions
+    };
+    const event = { key: 'z', ctrlKey: true, metaKey: false, preventDefault: t.mock.fn() };
+
+    // @ts-expect-error - Mock event
+    handleKeyboardShortcut(event, context);
+
+    assert.strictEqual(event.preventDefault.mock.callCount(), 1);
+    assert.strictEqual(actions.dispatch.mock.callCount(), 1);
+    assert.deepStrictEqual(actions.dispatch.mock.calls[0].arguments[0], { type: 'UNDO' });
+});
+
+test('Keyboard Shortcuts - Meta+Z dispatches UNDO', (t) => {
+    const actions = createMockActions();
+    const context: KeyboardShortcutContext = {
+        state: createMockState(),
+        focusedId: null,
+        isInput: false,
+        actions
+    };
+    const event = { key: 'z', ctrlKey: false, metaKey: true, preventDefault: t.mock.fn() };
+
+    // @ts-expect-error - Mock event
+    handleKeyboardShortcut(event, context);
+
+    assert.strictEqual(event.preventDefault.mock.callCount(), 1);
+    assert.strictEqual(actions.dispatch.mock.callCount(), 1);
+    assert.deepStrictEqual(actions.dispatch.mock.calls[0].arguments[0], { type: 'UNDO' });
+});
+
+test('Keyboard Shortcuts - Ctrl+Z is ignored if isInput is true', (t) => {
+    const actions = createMockActions();
+    const context: KeyboardShortcutContext = {
+        state: createMockState(),
+        focusedId: null,
+        isInput: true,
+        actions
+    };
+    const event = { key: 'z', ctrlKey: true, metaKey: false, preventDefault: t.mock.fn() };
+
+    // @ts-expect-error - Mock event
+    handleKeyboardShortcut(event, context);
+
+    assert.strictEqual(event.preventDefault.mock.callCount(), 0);
+    assert.strictEqual(actions.dispatch.mock.callCount(), 0);
+});
+
 test('No action if focused bullet does not exist', (t) => {
     const actions = createMockActions();
     const context: KeyboardShortcutContext = {

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -26,6 +26,8 @@ export interface KeyboardShortcutContext {
 // Partial KeyboardEvent interface for testing
 export interface KeyboardEventLike {
     key: string;
+    ctrlKey: boolean;
+    metaKey: boolean;
     preventDefault: () => void;
 }
 
@@ -45,6 +47,13 @@ export function handleKeyboardShortcut(
     if (isInput) return;
 
     const key = e.key.toLowerCase();
+
+    // Global Undo
+    if ((e.ctrlKey || e.metaKey) && key === 'z') {
+        e.preventDefault();
+        dispatch({ type: 'UNDO' });
+        return;
+    }
 
     // 1. Navigation
     if (key === 'j' || e.key === 'ArrowDown') {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from './contexts/AuthContext.tsx'
 import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import { NoteEditorProvider } from './contexts/NoteEditorContext.tsx'
 import { ConfirmationProvider } from './contexts/ConfirmationContext.tsx'
+import { ToastProvider } from './contexts/ToastContext.tsx'
 
 console.log("Main: Initializing bundle...");
 
@@ -17,7 +18,9 @@ createRoot(document.getElementById('root')!).render(
         <StoreProvider>
           <NoteEditorProvider>
             <ConfirmationProvider>
-              <App />
+              <ToastProvider>
+                <App />
+              </ToastProvider>
             </ConfirmationProvider>
           </NoteEditorProvider>
         </StoreProvider>

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useContext, useReducer, useEffect, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { AppState, Action } from './types';
 import { useAuth } from './contexts/AuthContext';
 import { performActionInFirestore, subscribeToUserData } from './lib/database';
 import { reducer, initialState } from './storeReducer';
 import { generateUUID } from './lib/utils';
+import { useToast } from './contexts/ToastContext';
 
 // --- Context ---
 const StoreContext = createContext<{
@@ -20,6 +21,8 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
     // 1. Initialize with basic state (no localStorage)
     const [state, rawDispatch] = useReducer(reducer, initialState);
     const { user } = useAuth();
+    const undoStack = useRef<Action[]>([]);
+    const { showToast } = useToast();
 
     // 2. Subscribe to Firestore
     useEffect(() => {
@@ -36,6 +39,18 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
     // 3. Dispatch Wrapper
     // This intercepts actions, generates IDs if needed, updates local state, AND calls Firestore
     const dispatch = useCallback(async (action: Action) => {
+        // --- UNDO ---
+        if (action.type === 'UNDO') {
+            const undoAction = undoStack.current.pop();
+            if (undoAction) {
+                // Execute undo
+                rawDispatch(undoAction);
+                if (user) performActionInFirestore(user.uid, undoAction, state);
+                showToast("Undone");
+            }
+            return;
+        }
+
         // Enforce ID generation for creations
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, prefer-const
         let enhancedAction: any = { ...action };
@@ -51,6 +66,36 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
             enhancedAction.payload.newId = generateUUID();
         }
 
+        // --- CAPTURE INVERSE ---
+        // We capture BEFORE executing the action so we have previous state
+        try {
+            if (enhancedAction.type === 'ADD_BULLET') {
+                undoStack.current = [{ type: 'DELETE_BULLET', payload: { id: enhancedAction.payload.id } }];
+            } else if (enhancedAction.type === 'DELETE_BULLET') {
+                const bullet = state.bullets[enhancedAction.payload.id];
+                if (bullet) {
+                    undoStack.current = [{ type: 'RESTORE_BULLET', payload: bullet }];
+                }
+            } else if (enhancedAction.type === 'UPDATE_BULLET') {
+                const bullet = state.bullets[enhancedAction.payload.id];
+                if (bullet) {
+                    undoStack.current = [{ type: 'RESTORE_BULLET', payload: bullet }];
+                }
+            } else if (
+                enhancedAction.type === 'MIGRATE_BULLET' ||
+                enhancedAction.type === 'ADD_COLLECTION' ||
+                enhancedAction.type === 'UPDATE_COLLECTION' ||
+                enhancedAction.type === 'DELETE_COLLECTION' ||
+                enhancedAction.type === 'REORDER_BULLETS' ||
+                enhancedAction.type === 'REORDER_COLLECTIONS'
+            ) {
+                undoStack.current = [];
+            }
+        } catch (e) {
+            console.error("Undo capture failed", e);
+            undoStack.current = [];
+        }
+
         // 1. Optimistic Update (Local)
         rawDispatch(enhancedAction);
 
@@ -61,7 +106,7 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
                 performActionInFirestore(user.uid, enhancedAction, state);
             }
         }
-    }, [state, user]);
+    }, [state, user, showToast]);
 
     const value = useMemo(() => ({ state, dispatch }), [state, dispatch]);
 

--- a/src/storeReducer.test.ts
+++ b/src/storeReducer.test.ts
@@ -326,4 +326,46 @@ describe('storeReducer', () => {
         assert.ok(state.bullets['loaded']);
         assert.strictEqual(state.preferences.groupByProject, true);
     });
+
+    test('RESTORE_BULLET restores a bullet state', () => {
+        const startState: AppState = {
+            ...initialState,
+            bullets: {
+                'b1': {
+                    id: 'b1',
+                    content: 'Modified',
+                    type: 'task',
+                    state: 'open',
+                    order: 1,
+                    createdAt: 100,
+                    updatedAt: 200,
+                    completedAt: undefined
+                }
+            }
+        };
+
+        const originalBullet: Bullet = {
+            id: 'b1',
+            content: 'Original',
+            type: 'task',
+            state: 'open',
+            order: 1,
+            createdAt: 100,
+            updatedAt: 100,
+            completedAt: undefined
+        };
+
+        const action: Action = {
+            type: 'RESTORE_BULLET',
+            payload: originalBullet
+        };
+
+        const state = reducer(startState, action);
+        assert.deepStrictEqual(state.bullets['b1'], originalBullet);
+    });
+
+    test('UNDO returns state as is', () => {
+        const state = reducer(initialState, { type: 'UNDO' });
+        assert.strictEqual(state, initialState);
+    });
 });

--- a/src/storeReducer.ts
+++ b/src/storeReducer.ts
@@ -220,6 +220,17 @@ export function reducer(state: AppState, action: Action): AppState {
             }
             return newState;
         }
+        case 'RESTORE_BULLET': {
+            return {
+                ...state,
+                bullets: {
+                    ...state.bullets,
+                    [action.payload.id]: action.payload,
+                },
+            };
+        }
+        case 'UNDO':
+            return state;
         default:
             return state;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,4 +56,6 @@ export type Action =
     | { type: 'REORDER_BULLETS'; payload: { items: { id: string, order: number }[] } }
     | { type: 'REORDER_COLLECTIONS'; payload: { items: { id: string, order: number }[] } } // Added action
     | { type: 'TOGGLE_PREFERENCE'; payload: { key: keyof AppState['preferences'] } }
-    | { type: 'LOAD_DATA'; payload: Partial<AppState> }; // Partial loading for sync
+    | { type: 'LOAD_DATA'; payload: Partial<AppState> } // Partial loading for sync
+    | { type: 'RESTORE_BULLET'; payload: Bullet }
+    | { type: 'UNDO'; payload?: void };

--- a/verification_script.py
+++ b/verification_script.py
@@ -1,0 +1,69 @@
+from playwright.sync_api import Page, expect, sync_playwright
+import time
+
+def verify_undo(page: Page):
+    print("Navigating to app...")
+    page.goto("http://localhost:5173")
+
+    # Wait for login
+    try:
+        print("Waiting for 'Last Task' or 'Today'...")
+        # Check for either header
+        expect(page.locator("h1:has-text('Last Task'), h1:has-text('Today')").first).to_be_visible(timeout=10000)
+    except:
+        print("Initial load failed or auth required. Screenshotting.")
+        page.screenshot(path="verification_load_fail.png")
+        raise
+
+    print("Adding task 'Task Undo Test'...")
+    # Find input
+    input_loc = page.locator("#main-bullet-editor-input")
+    input_loc.fill("Task Undo Test")
+    input_loc.press("Enter")
+
+    # Verify task added
+    print("Verifying task added...")
+    task_loc = page.get_by_text("Task Undo Test")
+    expect(task_loc).to_be_visible()
+
+    # Blur input to ensure Ctrl+Z triggers App Undo
+    print("Blurring input...")
+    input_loc.blur()
+    # Click outside to be safe
+    page.locator("body").click(position={"x": 0, "y": 0})
+
+    # Wait a bit
+    time.sleep(0.5)
+
+    # Undo
+    print("Pressing Ctrl+Z...")
+    page.keyboard.press("Control+z")
+
+    # Verify Toast
+    print("Verifying toast...")
+    try:
+        expect(page.get_by_text("Undone")).to_be_visible(timeout=3000)
+        print("Toast appeared!")
+    except:
+        print("Toast did not appear!")
+        page.screenshot(path="verification_toast_fail.png")
+        raise
+
+    # Verify Task Removed
+    print("Verifying task removed...")
+    expect(task_loc).not_to_be_visible()
+
+    print("Success! Taking screenshot.")
+    page.screenshot(path="verification_undo_success.png")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            verify_undo(page)
+        except Exception as e:
+            print(f"Test failed: {e}")
+            raise e
+        finally:
+            browser.close()


### PR DESCRIPTION
This PR implements a single-level Undo feature for task operations, fulfilling the user request.

**Key Changes:**
1.  **Store Logic (`src/store.tsx`):** Introduced an `undoStack` (ref) to store the inverse of the last performed action (`ADD`, `UPDATE`, `DELETE`). The `dispatch` function intercepts these actions and pushes the corresponding inverse action (`DELETE`, `RESTORE`, `RESTORE`) to the stack.
2.  **Reducer & Types (`src/storeReducer.ts`, `src/types.ts`):** Added `RESTORE_BULLET` action to restore a full bullet snapshot, and `UNDO` action type.
3.  **Database Logic (`src/lib/database.logic.ts`):** Implemented `RESTORE_BULLET` persistence, using `setDoc` to overwrite the document while updating `updatedAt`.
4.  **UI Feedback (`src/contexts/ToastContext.tsx`):** Created a simple `ToastContext` to display a transient "Undone" message at the bottom of the screen.
5.  **Keyboard Shortcut (`src/lib/keyboardShortcuts.ts`):** Added a global handler for `Ctrl+Z` (or `Meta+Z`) to dispatch the `UNDO` action. Crucially, this respects the existing `isInput` check to allow native browser undo for text editing.

**Verification:**
-   Existing tests passed (`npm test`).
-   New tests added to `src/storeReducer.test.ts` to verify `RESTORE_BULLET`.
-   New tests added to `src/lib/keyboardShortcuts.test.ts` to verify `Ctrl+Z` dispatch logic and input exclusion.
-   Frontend verification (Playwright) was attempted but skipped due to missing `vite` binary in the restricted environment preventing the dev server from starting. Logic verification via unit tests provides high confidence.

---
*PR created automatically by Jules for task [11444069377639277883](https://jules.google.com/task/11444069377639277883) started by @mrembert*