### PR TITLE
feat: Update 'Next Week' migration to target next Monday

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { addDays, addMonths, startOfMonth, format } from 'date-fns';
+import { addDays, addMonths, startOfMonth, format, addWeeks, startOfWeek } from 'date-fns';
 import { ArrowRight, X, Calendar as CalendarIcon, Trash2, Keyboard } from 'lucide-react';
 import { usePopupNavigation } from '../hooks/usePopupNavigation';
 import { Calendar } from './Calendar';
@@ -13,7 +13,7 @@ interface DatePickerProps {
 
 export function DatePicker({ currentDate, onSelectDate, onCancel }: DatePickerProps) {
     const today = new Date();
-    const nextWeek = addDays(today, 7);
+    const nextWeek = startOfWeek(addWeeks(today, 1), { weekStartsOn: 1 });
     const nextMonth = startOfMonth(addMonths(today, 1));
     const [isCustom, setIsCustom] = useState(false);
     const [isManual, setIsManual] = useState(false);

--- a/src/components/MigrationPicker.tsx
+++ b/src/components/MigrationPicker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import { addDays, addMonths, startOfMonth, format } from 'date-fns';
+import { addDays, addMonths, startOfMonth, format, addWeeks, startOfWeek } from 'date-fns';
 import { ArrowRight, X, Calendar as CalendarIcon, Keyboard } from 'lucide-react';
 import { usePopupNavigation } from '../hooks/usePopupNavigation';
 import { Calendar } from './Calendar';
@@ -12,7 +12,7 @@ interface MigrationPickerProps {
 
 export function MigrationPicker({ onSelectDate, onCancel }: MigrationPickerProps) {
     const today = new Date();
-    const nextWeek = addDays(today, 7);
+    const nextWeek = startOfWeek(addWeeks(today, 1), { weekStartsOn: 1 });
     const nextMonth = startOfMonth(addMonths(today, 1));
     const monthAfterNext = addMonths(nextMonth, 1);
     const [isCustom, setIsCustom] = React.useState(false);


### PR DESCRIPTION
Updated the 'Next Week' date selection logic in both the Migration Picker and Date Picker components. Previously, 'Next Week' simply added 7 days to the current date. The new implementation correctly targets the Monday of the following week, ensuring better alignment with weekly planning workflows. This was achieved using `addWeeks(today, 1)` followed by `startOfWeek(..., { weekStartsOn: 1 })`.

---
*PR created automatically by Jules for task [3832965358076659059](https://jules.google.com/task/3832965358076659059) started by @mrembert*