### PR TITLE
Fix recurring event creation and add stop repeating option

### DIFF
--- a/src/components/BulletItem.tsx
+++ b/src/components/BulletItem.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Trash, FileText, FolderInput, Calendar, MoreVertical, Edit2, Repeat } from 'lucide-react';
+import { Trash, FileText, FolderInput, Calendar, MoreVertical, Edit2, Repeat, XCircle } from 'lucide-react';
 import type { Bullet } from '../types';
 import { useStore } from '../store';
 import { BulletIcon } from './BulletIcon';
@@ -108,6 +108,39 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
             }
         });
         showToast(`Updated ${ids.length} future events.`);
+        setMenuOpen(false);
+    };
+
+    const handleStopRecurring = () => {
+        requestConfirmation({
+            title: 'Stop Repeating',
+            message: 'Stop repeating this event? This will remove the recurrence rule from this event and delete all future instances.',
+            isDanger: true,
+            confirmLabel: 'Stop Repeating',
+            onConfirm: () => {
+                const futureBullets = Object.values(state.bullets).filter(b =>
+                    b.recurringId === bullet.recurringId &&
+                    b.date && bullet.date && b.date > bullet.date
+                );
+                const ids = futureBullets.map(b => b.id);
+
+                if (ids.length > 0) {
+                    dispatch({ type: 'DELETE_BULLETS', payload: { ids } });
+                }
+
+                dispatch({
+                    type: 'UPDATE_BULLET',
+                    payload: {
+                        id: bullet.id,
+                        recurringId: null,
+                        recurrenceRule: null
+                    }
+                });
+
+                showToast(`Recurrence stopped. ${ids.length} future events deleted.`);
+                setMenuOpen(false);
+            }
+        });
         setMenuOpen(false);
     };
 
@@ -432,13 +465,22 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
 
                                 {/* Recurring Actions */}
                                 {isRecurring ? (
-                                    <button
-                                        onClick={handleUpdateFuture}
-                                        className="btn btn-ghost"
-                                        style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
-                                    >
-                                        <Repeat size={14} /> Update Future Events
-                                    </button>
+                                    <>
+                                        <button
+                                            onClick={handleUpdateFuture}
+                                            className="btn btn-ghost"
+                                            style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
+                                        >
+                                            <Repeat size={14} /> Update Future Events
+                                        </button>
+                                        <button
+                                            onClick={handleStopRecurring}
+                                            className="btn btn-ghost"
+                                            style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
+                                        >
+                                            <XCircle size={14} /> Stop Repeating
+                                        </button>
+                                    </>
                                 ) : (
                                     <div style={{ position: 'relative' }}>
                                         <button

--- a/src/components/RecurrencePicker.tsx
+++ b/src/components/RecurrencePicker.tsx
@@ -49,8 +49,7 @@ export function RecurrencePicker({ startDate, initialConfig, onChange, onClose }
         // But usually startDate is fixed for the picker session
     }, [startDate]);
 
-    // Construct config on change
-    useEffect(() => {
+    const handleSave = () => {
         if (frequency === 'none') {
             onChange(null);
             return;
@@ -75,7 +74,7 @@ export function RecurrencePicker({ startDate, initialConfig, onChange, onClose }
         }
 
         onChange(config);
-    }, [frequency, interval, monthlyType, monthDay, monthWeek, monthWeekDay, onChange]);
+    };
 
     return createPortal(
         <div className="picker-overlay" onClick={onClose}>
@@ -166,22 +165,7 @@ export function RecurrencePicker({ startDate, initialConfig, onChange, onClose }
                 <div style={{ marginTop: '1.5rem', paddingTop: '1rem', borderTop: '1px solid hsl(var(--color-border))', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
                     <button onClick={onClose} className="btn btn-ghost">Cancel</button>
                     <button
-                        onClick={() => {
-                            // Trigger the change with the current config to confirm
-                            const config: RecurrenceConfig = {
-                                frequency: frequency as RecurrenceFrequency,
-                                interval,
-                            };
-                            if (frequency === 'monthly') {
-                                if (monthlyType === 'date') {
-                                    config.monthDay = monthDay;
-                                } else {
-                                    config.monthWeek = monthWeek;
-                                    config.monthWeekDay = monthWeekDay;
-                                }
-                            }
-                            onChange(config);
-                        }}
+                        onClick={handleSave}
                         className="btn btn-primary"
                         disabled={frequency === 'none'}
                     >

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,8 +14,8 @@ export interface Bullet {
     completedAt?: number;
     longFormContent?: string; // For meeting notes or detailed descriptions
     parentNoteId?: string; // ID of the note where this task was created
-    recurringId?: string; // ID linking recurring instances
-    recurrenceRule?: string; // Stringified rule (e.g. "daily", "weekly", or JSON)
+    recurringId?: string | null; // ID linking recurring instances
+    recurrenceRule?: string | null; // Stringified rule (e.g. "daily", "weekly", or JSON)
 }
 
 export interface Collection {
@@ -47,9 +47,9 @@ export interface AppState {
 }
 
 export type Action =
-    | { type: 'ADD_BULLET'; payload: { id: string; content: string; type: BulletType; date?: string | null; collectionId?: string | null; parentNoteId?: string; recurringId?: string; recurrenceRule?: string } }
+    | { type: 'ADD_BULLET'; payload: { id: string; content: string; type: BulletType; date?: string | null; collectionId?: string | null; parentNoteId?: string; recurringId?: string | null; recurrenceRule?: string | null } }
     | { type: 'ADD_BULLETS'; payload: { bullets: Bullet[] } } // Batch add
-    | { type: 'UPDATE_BULLET'; payload: { id: string; content?: string; state?: BulletState; longFormContent?: string; date?: string | null; collectionId?: string | null; recurringId?: string; recurrenceRule?: string } }
+    | { type: 'UPDATE_BULLET'; payload: { id: string; content?: string; state?: BulletState; longFormContent?: string; date?: string | null; collectionId?: string | null; recurringId?: string | null; recurrenceRule?: string | null } }
     | { type: 'UPDATE_BULLETS'; payload: { ids: string[]; updates: Partial<Bullet> } } // Batch update
     | { type: 'DELETE_BULLET'; payload: { id: string } }
     | { type: 'DELETE_BULLETS'; payload: { ids: string[] } } // Batch delete


### PR DESCRIPTION
This PR fixes the issue where recurring events were automatically created (51 instances) upon opening the picker. It also adds a 'Stop Repeating' option to recurring items.

Changes:
- Refactored `RecurrencePicker` to remove auto-submit `useEffect` and rely on a "Save" button action.
- Updated `Bullet` and `Action` types in `types.ts` to allow `null` for `recurringId` and `recurrenceRule`.
- Added `handleStopRecurring` to `BulletItem.tsx` which removes recurrence from the current item and deletes future instances.
- Added a "Stop Repeating" button to the recurring item menu in `BulletItem.tsx` with confirmation.
- Imported `XCircle` icon in `BulletItem.tsx` from `lucide-react`.

---
*PR created automatically by Jules for task [9004899150330545611](https://jules.google.com/task/9004899150330545611) started by @mrembert*