### PR TITLE
Remove 'Update Future Events' feature from recurring tasks

### DIFF
--- a/src/components/BulletItem.tsx
+++ b/src/components/BulletItem.tsx
@@ -80,37 +80,6 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
         setShowDatePicker(false);
     };
 
-    const handleUpdateFuture = () => {
-        if (!bullet.recurringId) return;
-
-        const futureBullets = Object.values(state.bullets).filter(b =>
-            b.recurringId === bullet.recurringId &&
-            b.id !== bullet.id &&
-            b.date && bullet.date && b.date > bullet.date
-        );
-
-        if (futureBullets.length === 0) {
-            showToast("No future events found.");
-            setMenuOpen(false);
-            return;
-        }
-
-        const ids = futureBullets.map(b => b.id);
-        dispatch({
-            type: 'UPDATE_BULLETS',
-            payload: {
-                ids,
-                updates: {
-                    content: bullet.content,
-                    type: bullet.type,
-                    longFormContent: bullet.longFormContent
-                }
-            }
-        });
-        showToast(`Updated ${ids.length} future events.`);
-        setMenuOpen(false);
-    };
-
     const handleStopRecurring = () => {
         requestConfirmation({
             title: 'Stop Repeating',
@@ -465,22 +434,13 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
 
                                 {/* Recurring Actions */}
                                 {isRecurring ? (
-                                    <>
-                                        <button
-                                            onClick={handleUpdateFuture}
-                                            className="btn btn-ghost"
-                                            style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
-                                        >
-                                            <Repeat size={14} /> Update Future Events
-                                        </button>
-                                        <button
-                                            onClick={handleStopRecurring}
-                                            className="btn btn-ghost"
-                                            style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
-                                        >
-                                            <XCircle size={14} /> Stop Repeating
-                                        </button>
-                                    </>
+                                    <button
+                                        onClick={handleStopRecurring}
+                                        className="btn btn-ghost"
+                                        style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
+                                    >
+                                        <XCircle size={14} /> Stop Repeating
+                                    </button>
                                 ) : (
                                     <div style={{ position: 'relative' }}>
                                         <button


### PR DESCRIPTION
Removed the 'Update Future Events' menu item and associated logic (`handleUpdateFuture`) from `src/components/BulletItem.tsx`.

-   `src/components/BulletItem.tsx`: Removed `handleUpdateFuture` function and the "Update Future Events" button from the kebab menu.
-   Verified that `UPDATE_BULLETS` action is no longer used in this file but kept in the reducer for potential future use.
-   Verified that "Stop Repeating" functionality remains intact.
-   Ran existing unit tests to ensure no regressions in logic or reducer.

---
*PR created automatically by Jules for task [5059988778457708214](https://jules.google.com/task/5059988778457708214) started by @mrembert*