### PR TITLE
Add 'Migrate' option to task menu

### DIFF
--- a/src/components/BulletItem.tsx
+++ b/src/components/BulletItem.tsx
@@ -1,10 +1,11 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Trash, FileText, FolderInput, Calendar, MoreVertical, Repeat, XCircle } from 'lucide-react';
+import { Trash, FileText, FolderInput, Calendar, MoreVertical, Repeat, XCircle, ArrowRight } from 'lucide-react';
 import type { Bullet } from '../types';
 import { useStore } from '../store';
 import { BulletIcon } from './BulletIcon';
 import { DatePicker } from './DatePicker';
+import { MigrationPicker } from './MigrationPicker';
 import { ProjectPicker } from './ProjectPicker';
 import { RecurrencePicker } from './RecurrencePicker';
 import { generateRecurringDates, type RecurrenceConfig } from '../lib/recurrence';
@@ -26,6 +27,7 @@ interface BulletItemProps {
 export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet, isFocused, onMenuOpenChange, depth = 0 }, ref) => {
     const { state, dispatch } = useStore();
     const [showDatePicker, setShowDatePicker] = useState(false);
+    const [showMigrationPicker, setShowMigrationPicker] = useState(false);
     const [showProjectPicker, setShowProjectPicker] = useState(false);
     const [showRecurrencePicker, setShowRecurrencePicker] = useState(false);
     const [menuOpen, setMenuOpen] = useState(false);
@@ -403,6 +405,7 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
                                 onClick={() => {
                                     setMenuOpen(false);
                                     setShowDatePicker(false);
+                                    setShowMigrationPicker(false);
                                     setShowProjectPicker(false);
                                     setShowRecurrencePicker(false);
                                 }}
@@ -421,6 +424,25 @@ export const BulletItem = forwardRef<HTMLDivElement, BulletItemProps>(({ bullet,
                                 display: 'flex',
                                 flexDirection: 'column',
                             }}>
+                                {/* Migrate */}
+                                <button
+                                    onClick={() => setShowMigrationPicker(!showMigrationPicker)}
+                                    className="btn btn-ghost"
+                                    style={{ justifyContent: 'flex-start', width: '100%', fontSize: '0.85rem' }}
+                                >
+                                    <ArrowRight size={14} /> Migrate to...
+                                </button>
+                                {showMigrationPicker && (
+                                    <MigrationPicker
+                                        onSelectDate={(date) => {
+                                            dispatch({ type: 'MIGRATE_BULLET', payload: { id: bullet.id, targetDate: date } });
+                                            setShowMigrationPicker(false);
+                                            setMenuOpen(false);
+                                        }}
+                                        onCancel={() => setShowMigrationPicker(false)}
+                                    />
+                                )}
+
                                 {/* Date Picker */}
                                 <button
                                     onClick={() => setShowDatePicker(!showDatePicker)}


### PR DESCRIPTION
The "Show Moved" button was not functioning as expected because the UI only offered a "Reschedule" (Move) action via the "Assign Date" button, which does not leave a "migrated" ghost task. This change adds a dedicated "Migrate to..." option in the task menu, utilizing the existing `MigrationPicker` component and `MIGRATE_BULLET` action to properly migrate tasks and enable the "Show Moved" functionality.

---
*PR created automatically by Jules for task [2176693054688402881](https://jules.google.com/task/2176693054688402881) started by @mrembert*