### PR TITLE
Fix drag functionality for task items by resolving dnd-kit and framer-motion conflict

### DIFF
--- a/src/components/SortableBulletItem.tsx
+++ b/src/components/SortableBulletItem.tsx
@@ -1,4 +1,3 @@
-
 import { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -33,22 +32,22 @@ export function SortableBulletItem({ bullet, isFocused, depth = 0 }: SortableBul
     };
 
     return (
-        <motion.div
-            ref={setNodeRef}
-            style={style}
-            layout
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, height: 0, overflow: 'hidden' }}
-            transition={{ duration: 0.2 }}
-        >
-            <BulletItem
-                bullet={bullet}
-                isFocused={isFocused}
-                onMenuOpenChange={setMenuOpen}
-                depth={depth}
-                dragHandleProps={{ attributes, listeners }}
-            />
-        </motion.div>
+        <div ref={setNodeRef} style={style}>
+            <motion.div
+                layout
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, height: 0, overflow: 'hidden' }}
+                transition={{ duration: 0.2 }}
+            >
+                <BulletItem
+                    bullet={bullet}
+                    isFocused={isFocused}
+                    onMenuOpenChange={setMenuOpen}
+                    depth={depth}
+                    dragHandleProps={{ attributes, listeners }}
+                />
+            </motion.div>
+        </div>
     );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -408,6 +408,7 @@ body {
 
 .drag-handle {
     cursor: grab;
+    touch-action: none;
     color: hsl(var(--color-text-secondary));
     display: flex;
     align-items: center;
@@ -434,6 +435,7 @@ body {
     align-items: center;
     justify-content: center;
     cursor: grab;
+    touch-action: none;
     color: hsl(var(--color-text-secondary));
     padding: 0.25rem;
     margin-right: -0.25rem;


### PR DESCRIPTION
Fixed an issue where drag handles were visible but non-functional. The root causes were:
1. Missing `touch-action: none` on drag handles, which could cause pointer events to be interpreted as scrolling.
2. A conflict between `@dnd-kit` and `framer-motion` where `motion.div`'s layout animation system was overriding the CSS transform applied by `dnd-kit` during dragging.

The fix involves adding the CSS property and refactoring `SortableBulletItem` to apply the sortable ref and styles to a parent `div`, allowing `motion.div` to handle internal animations without interference.

---
*PR created automatically by Jules for task [16984622666674382230](https://jules.google.com/task/16984622666674382230) started by @mrembert*