### PR TITLE
feat: add mobile-only rearrange toggle for task lists

### DIFF
--- a/src/components/CollectionView.tsx
+++ b/src/components/CollectionView.tsx
@@ -3,7 +3,7 @@ import { useStore } from '../store';
 import { calculateDepth, getEffectiveCollectionId } from '../lib/bulletUtils';
 import { SortableBulletItem } from './SortableBulletItem';
 import { BulletEditor } from './BulletEditor';
-import { Eye, EyeOff, Grid, Layers } from 'lucide-react';
+import { Eye, EyeOff, Grid, Layers, ArrowUpDown } from 'lucide-react';
 import {
     DndContext,
     closestCenter,
@@ -29,6 +29,7 @@ export function CollectionView() {
     const { sortByType } = state.preferences;
     const { focusedId, setVisibleIds } = useKeyboardFocus();
     const [showCompleted, setShowCompleted] = useState(false);
+    const [isRearrangeMode, setIsRearrangeMode] = useState(false);
 
     const collection = collectionId ? state.collections[collectionId] : null;
 
@@ -107,26 +108,37 @@ export function CollectionView() {
                             {collection.title}
                         </h1>
                     </div>
-                    <button
-                        onClick={() => dispatch({ type: 'TOGGLE_PREFERENCE', payload: { key: 'sortByType' } })}
-                        className={`btn ${sortByType ? 'btn-primary' : 'btn-ghost'}`}
-                        style={{ color: 'hsl(var(--color-text-secondary))', marginRight: '0.5rem' }}
-                        title={sortByType ? "Sorted by Type" : "Sort by Custom Order"}
-                    >
-                        {sortByType ? <Layers size={20} /> : <Grid size={20} />}
-                    </button>
-                    <button
-                        onClick={() => setShowCompleted(!showCompleted)}
-                        className="btn btn-ghost"
-                        style={{ color: 'hsl(var(--color-text-secondary))' }}
-                        title={showCompleted ? "Hide Completed" : "Show Completed"}
-                    >
-                        {showCompleted ? <EyeOff size={20} /> : <Eye size={20} />}
-                    </button>
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                        <button
+                            onClick={() => setIsRearrangeMode(!isRearrangeMode)}
+                            className={`btn ${isRearrangeMode ? 'btn-primary' : 'btn-ghost'} mobile-only`}
+                            style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem', marginRight: '0.5rem', color: isRearrangeMode ? 'white' : 'hsl(var(--color-text-secondary))' }}
+                            title={isRearrangeMode ? "Done Rearranging" : "Rearrange Tasks"}
+                        >
+                            <ArrowUpDown size={20} />
+                            {isRearrangeMode ? " Done" : ""}
+                        </button>
+                        <button
+                            onClick={() => dispatch({ type: 'TOGGLE_PREFERENCE', payload: { key: 'sortByType' } })}
+                            className={`btn ${sortByType ? 'btn-primary' : 'btn-ghost'}`}
+                            style={{ color: 'hsl(var(--color-text-secondary))', marginRight: '0.5rem' }}
+                            title={sortByType ? "Sorted by Type" : "Sort by Custom Order"}
+                        >
+                            {sortByType ? <Layers size={20} /> : <Grid size={20} />}
+                        </button>
+                        <button
+                            onClick={() => setShowCompleted(!showCompleted)}
+                            className="btn btn-ghost"
+                            style={{ color: 'hsl(var(--color-text-secondary))' }}
+                            title={showCompleted ? "Hide Completed" : "Show Completed"}
+                        >
+                            {showCompleted ? <EyeOff size={20} /> : <Eye size={20} />}
+                        </button>
+                    </div>
                 </div>
             </header>
 
-            <div className="collection-list">
+            <div className={`collection-list ${isRearrangeMode ? 'rearrange-active' : ''}`}>
                 {bullets.length === 0 && (
                     <div style={{ padding: '2rem', textAlign: 'center', color: 'hsl(var(--color-text-secondary))', opacity: 0.5 }}>
                         Empty collection. Start adding items below.

--- a/src/components/DailyLog.tsx
+++ b/src/components/DailyLog.tsx
@@ -1,14 +1,15 @@
 import { useStore } from '../store';
 import { BulletEditor } from './BulletEditor';
 import { TaskGroupList } from './TaskGroupList';
-import { CheckSquare, Grid, Layers } from 'lucide-react';
+import { CheckSquare, Grid, Layers, ArrowUpDown } from 'lucide-react';
 import { useKeyboardFocus } from '../contexts/KeyboardFocusContext';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export function DailyLog() {
     const { state, dispatch } = useStore();
     const { date } = state.view;
     const { groupByProject, showCompleted, sortByType } = state.preferences;
+    const [isRearrangeMode, setIsRearrangeMode] = useState(false);
 
     // Filter bullets for the current date
     const dailyBullets = useMemo(() => Object.values(state.bullets)
@@ -50,6 +51,15 @@ export function DailyLog() {
                 justifyContent: 'flex-end'
             }}>
                 <button
+                    onClick={() => setIsRearrangeMode(!isRearrangeMode)}
+                    className={`btn ${isRearrangeMode ? 'btn-primary' : 'btn-ghost'} mobile-only`}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
+                    title={isRearrangeMode ? "Done Rearranging" : "Rearrange Tasks"}
+                >
+                    <ArrowUpDown size={16} />
+                    {isRearrangeMode ? " Done" : " Rearrange"}
+                </button>
+                <button
                     onClick={toggleGrouping}
                     className={`btn ${groupByProject ? 'btn-primary' : 'btn-ghost'}`}
                     style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
@@ -81,6 +91,7 @@ export function DailyLog() {
             <TaskGroupList
                 bullets={dailyBullets}
                 enableDragAndDrop={true}
+                isRearrangeMode={isRearrangeMode}
             />
 
             <BulletEditor />

--- a/src/components/TaskGroupList.tsx
+++ b/src/components/TaskGroupList.tsx
@@ -26,9 +26,10 @@ interface TaskGroupListProps {
     bullets: Bullet[];
     enableDragAndDrop?: boolean;
     onDragEnd?: (event: DragEndEvent) => void;
+    isRearrangeMode?: boolean;
 }
 
-export function TaskGroupList({ bullets, enableDragAndDrop, onDragEnd }: TaskGroupListProps) {
+export function TaskGroupList({ bullets, enableDragAndDrop, onDragEnd, isRearrangeMode }: TaskGroupListProps) {
     const { state } = useStore();
     const { focusedId, setVisibleIds } = useKeyboardFocus();
     const { groupByProject, showCompleted } = state.preferences;
@@ -171,7 +172,7 @@ export function TaskGroupList({ bullets, enableDragAndDrop, onDragEnd }: TaskGro
             const allGroupIds = ['group-unassigned', ...projectIds];
             return (
                 <SortableContext items={allGroupIds} strategy={verticalListSortingStrategy}>
-                    <div className="task-group-list">
+                    <div className={`task-group-list ${isRearrangeMode ? 'rearrange-active' : ''}`}>
                         {unassigned.length > 0 || projectIds.length === 0 ? (
                             <div className="group-section" style={{ marginBottom: '2rem' }}>
                                 <SortableProjectHeader id="group-unassigned" title="Inbox / Unassigned" isUnassigned />
@@ -219,7 +220,7 @@ export function TaskGroupList({ bullets, enableDragAndDrop, onDragEnd }: TaskGro
                 items={filteredBullets.map((b: Bullet) => b.id)}
                 strategy={verticalListSortingStrategy}
             >
-                <div className="task-list">
+                <div className={`task-list ${isRearrangeMode ? 'rearrange-active' : ''}`}>
                     {filteredBullets.length === 0 ? (
                         <div style={{ padding: '2rem', textAlign: 'center', color: 'hsl(var(--color-text-secondary))', opacity: 0.5 }}>
                             No entries found.

--- a/src/components/WeekLog.tsx
+++ b/src/components/WeekLog.tsx
@@ -1,14 +1,15 @@
 import { useStore } from '../store';
 import { BulletEditor } from './BulletEditor';
 import { format, startOfWeek, addDays, isSameDay, parseISO, endOfWeek } from 'date-fns';
-import { ChevronLeft, ChevronRight, Grid, Layers, CheckSquare } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Grid, Layers, CheckSquare, ArrowUpDown } from 'lucide-react';
 import { TaskGroupList } from './TaskGroupList';
 import { useKeyboardFocus } from '../contexts/KeyboardFocusContext';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 export function WeekLog() {
     const { state, dispatch } = useStore();
     const { groupByProject, showCompleted, sortByType } = state.preferences;
+    const [isRearrangeMode, setIsRearrangeMode] = useState(false);
 
     // Use state.view.date as the anchor for the week
     const currentDate = parseISO(state.view.date);
@@ -99,6 +100,15 @@ export function WeekLog() {
                 justifyContent: 'flex-end'
             }}>
                 <button
+                    onClick={() => setIsRearrangeMode(!isRearrangeMode)}
+                    className={`btn ${isRearrangeMode ? 'btn-primary' : 'btn-ghost'} mobile-only`}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
+                    title={isRearrangeMode ? "Done Rearranging" : "Rearrange Tasks"}
+                >
+                    <ArrowUpDown size={16} />
+                    {isRearrangeMode ? " Done" : " Rearrange"}
+                </button>
+                <button
                     onClick={toggleGrouping}
                     className={`btn ${groupByProject ? 'btn-primary' : 'btn-ghost'}`}
                     style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
@@ -137,7 +147,11 @@ export function WeekLog() {
                 flexDirection: 'column'
             }}>
                 <div style={{ flex: 1 }}>
-                    <TaskGroupList bullets={weekBullets} enableDragAndDrop={true} />
+                    <TaskGroupList
+                        bullets={weekBullets}
+                        enableDragAndDrop={true}
+                        isRearrangeMode={isRearrangeMode}
+                    />
                 </div>
 
                 <div style={{ marginTop: '1.5rem', paddingTop: '1rem', borderTop: '1px solid hsl(var(--color-text-secondary) / 0.1)' }}>

--- a/src/index.css
+++ b/src/index.css
@@ -441,7 +441,8 @@ body {
     margin-right: -0.25rem;
     border-radius: var(--radius-sm);
     transition: opacity 0.2s ease, background-color 0.2s ease;
-    /* Default visibility (Mobile / Base) */
+
+    /* Default visibility (Base/Mobile) - Changed: Hidden by default on mobile unless active */
     opacity: 0.5;
     min-width: 24px; /* Ensure touch target isn't too small visually */
     min-height: 24px;
@@ -451,9 +452,30 @@ body {
     cursor: grabbing;
 }
 
+.mobile-only {
+    display: none;
+}
+
+/* Mobile Logic */
+@media (max-width: 768px) {
+    .task-drag-handle {
+        display: none;
+    }
+
+    /* Only show when parent has rearrange-active class */
+    .rearrange-active .task-drag-handle {
+        display: flex;
+    }
+
+    .mobile-only {
+        display: inline-flex;
+    }
+}
+
 /* Desktop Hover Behavior */
 @media (min-width: 769px) {
     .task-drag-handle {
+        display: flex; /* Always display on desktop, rely on opacity */
         opacity: 0;
     }
 
@@ -469,5 +491,9 @@ body {
     /* Show when keyboard focused */
     .task-item.keyboard-focused .task-drag-handle {
         opacity: 0.5;
+    }
+
+    .mobile-only {
+        display: none;
     }
 }


### PR DESCRIPTION
Implemented a mobile-specific "Rearrange" toggle to declutter the UI. Drag handles are now hidden by default on mobile devices and only appear when the user explicitly activates "Rearrange" mode via a new button in the view controls. This change preserves the existing hover-based drag functionality for desktop users.

---
*PR created automatically by Jules for task [18295471133250718032](https://jules.google.com/task/18295471133250718032) started by @mrembert*