### PR TITLE
Fix rearrange toggle not showing drag handles on mobile

### DIFF
--- a/src/components/TaskGroupList.tsx
+++ b/src/components/TaskGroupList.tsx
@@ -238,7 +238,7 @@ export function TaskGroupList({ bullets, enableDragAndDrop, onDragEnd, isRearran
                 </div>
             </SortableContext>
         );
-    }, [groupByProject, unassigned, projectIds, grouped, focusedId, state.bullets, state.collections, visibleIdsSet, filteredBullets]);
+    }, [groupByProject, unassigned, projectIds, grouped, focusedId, state.bullets, state.collections, visibleIdsSet, filteredBullets, isRearrangeMode]);
 
     if (enableDragAndDrop) {
         return (


### PR DESCRIPTION
The `dndContent` in `TaskGroupList.tsx` was memoized without `isRearrangeMode` in its dependency array. This caused the component to not re-render when the rearrange mode was toggled, leaving the drag handles hidden on mobile devices. Adding the dependency fixes the issue.

---
*PR created automatically by Jules for task [6531828682532170160](https://jules.google.com/task/6531828682532170160) started by @mrembert*