### PR TITLE
feat: persist user view preferences (flat vs nested) to localStorage

### DIFF
--- a/src/store.tsx
+++ b/src/store.tsx
@@ -36,7 +36,14 @@ export function StoreProvider({ children }: { children: React.ReactNode }) {
         return () => unsubscribe();
     }, [user]);
 
-    // 3. Dispatch Wrapper
+    // 3. Persist preferences to localStorage
+    useEffect(() => {
+        if (typeof window !== 'undefined' && window.localStorage) {
+            localStorage.setItem('preferences', JSON.stringify(state.preferences));
+        }
+    }, [state.preferences]);
+
+    // 4. Dispatch Wrapper
     // This intercepts actions, generates IDs if needed, updates local state, AND calls Firestore
     const dispatch = useCallback(async (action: Action) => {
         // --- UNDO ---

--- a/src/storeReducer.ts
+++ b/src/storeReducer.ts
@@ -2,6 +2,26 @@ import type { AppState, Bullet, Action } from './types';
 import { getTodayDate } from './lib/utils.ts';
 
 
+const defaultPreferences = {
+    groupByProject: false,
+    showCompleted: true,
+    sortByType: false,
+};
+
+function getInitialPreferences() {
+    try {
+        if (typeof window !== 'undefined' && window.localStorage) {
+            const stored = window.localStorage.getItem('preferences');
+            if (stored) {
+                return { ...defaultPreferences, ...JSON.parse(stored) };
+            }
+        }
+    } catch (e) {
+        console.warn('Failed to parse preferences from localStorage', e);
+    }
+    return defaultPreferences;
+}
+
 // --- Initial State ---
 export const initialState: AppState = {
     bullets: {},
@@ -10,11 +30,7 @@ export const initialState: AppState = {
         mode: 'daily',
         date: getTodayDate(),
     },
-    preferences: {
-        groupByProject: false,
-        showCompleted: true,
-        sortByType: false,
-    },
+    preferences: getInitialPreferences(),
 };
 
 // --- Reducer ---


### PR DESCRIPTION
Fixes #61 by remembering the user's choice for 'nested' vs 'flat' task views.

Currently, if a user toggles their view to "nested" (Group by Project), the setting is lost as soon as the app is refreshed because `preferences` are only held in memory.

This PR implements `localStorage` persistence for the `preferences` slice of the `AppState`.
- Upon initialization, `getInitialPreferences()` safely attempts to read and parse the user's settings. If unavailable or if it fails, it falls back to the defaults.
- Whenever any preference is toggled (e.g., via the Flat/Nested button in DailyLog), a `useEffect` hook in the `StoreProvider` automatically stringifies and updates the `localStorage` key.
- Safe-guards (`typeof window !== 'undefined'`) are used to prevent `ReferenceError` during server-side operations or local tests (like `node:test`).

---
*PR created automatically by Jules for task [3634090837993048156](https://jules.google.com/task/3634090837993048156) started by @mrembert*