### PR TITLE
⚡ Optimize REORDER_BULLETS by utilizing Firestore batch writes

### DIFF
--- a/src/lib/database.logic.ts
+++ b/src/lib/database.logic.ts
@@ -190,10 +190,12 @@ export async function performActionInFirestoreLogic(
                 break;
             }
             case 'REORDER_BULLETS': {
-                const batchPromises = action.payload.items.map(item =>
-                    deps.updateDoc(deps.doc(usersRef, 'bullets', item.id), { order: item.order })
-                );
-                await Promise.all(batchPromises);
+                const batch = deps.writeBatch(db);
+                action.payload.items.forEach(item => {
+                    const ref = deps.doc(usersRef, 'bullets', item.id);
+                    batch.update(ref, { order: item.order });
+                });
+                await batch.commit();
                 break;
             }
         }

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -10,6 +10,7 @@ const mockOnSnapshot = mock.fn();
 const mockSetDoc = mock.fn();
 const mockUpdateDoc = mock.fn();
 const mockDeleteDoc = mock.fn();
+const mockWriteBatch = mock.fn();
 
 const deps = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +25,8 @@ const deps = {
     updateDoc: mockUpdateDoc as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     deleteDoc: mockDeleteDoc as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    writeBatch: mockWriteBatch as any,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,6 +41,7 @@ describe('database.logic', () => {
         mockSetDoc.mock.resetCalls();
         mockUpdateDoc.mock.resetCalls();
         mockDeleteDoc.mock.resetCalls();
+        mockWriteBatch.mock.resetCalls();
     });
 
     describe('subscribeToUserDataLogic', () => {
@@ -207,6 +211,47 @@ describe('database.logic', () => {
 
              assert.strictEqual(mockDeleteDoc.mock.callCount(), 1);
              assert.strictEqual(mockDeleteDoc.mock.calls[0].arguments[0], 'col-ref-c1');
+        });
+
+        it('should handle REORDER_BULLETS', async () => {
+             const action: Action = {
+                type: 'REORDER_BULLETS',
+                payload: {
+                    items: [
+                        { id: 'b1', order: 100 },
+                        { id: 'b2', order: 200 }
+                    ]
+                }
+            };
+
+            const mockBatchUpdate = mock.fn();
+            const mockBatchCommit = mock.fn(async () => {});
+
+            mockWriteBatch.mock.mockImplementation(() => ({
+                update: mockBatchUpdate,
+                commit: mockBatchCommit
+            }));
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            mockDoc.mock.mockImplementation((...args: any[]) => {
+                if (args.includes('bullets')) return `bullet-ref-${args[2]}`;
+                return 'user-ref';
+            });
+
+             await performActionInFirestoreLogic(deps, mockDb, mockUid, action);
+
+             assert.strictEqual(mockWriteBatch.mock.callCount(), 1);
+             assert.strictEqual(mockBatchUpdate.mock.callCount(), 2);
+
+             const updateArgs1 = mockBatchUpdate.mock.calls[0].arguments;
+             assert.strictEqual(updateArgs1[0], 'bullet-ref-b1');
+             assert.strictEqual(updateArgs1[1].order, 100);
+
+             const updateArgs2 = mockBatchUpdate.mock.calls[1].arguments;
+             assert.strictEqual(updateArgs2[0], 'bullet-ref-b2');
+             assert.strictEqual(updateArgs2[1].order, 200);
+
+             assert.strictEqual(mockBatchCommit.mock.callCount(), 1);
         });
     });
 });


### PR DESCRIPTION
💡 **What:**
The `REORDER_BULLETS` action in `src/lib/database.logic.ts` was refactored to use a Firestore `writeBatch` instead of using `Promise.all` over multiple `updateDoc` calls. A new unit test was added to `database.test.ts` to guarantee that the batched update mechanism functions correctly.

🎯 **Why:**
The previous implementation dispatched a separate network request to Firestore for every single bullet that was reordered. For users with large logs or collections, this could create a burst of HTTP requests that are inefficient and prone to intermittent latency. By batching these updates, we guarantee atomicity on the backend and dramatically reduce the network payload and round-trips from the client.

📊 **Measured Improvement:**
A formal local benchmark was not implemented because benchmarking network-bound latency effectively requires mocking or spinning up actual network/emulator topologies, which does not map linearly to production internet latency. However, based on Firestore architectural fundamentals: 
- **Baseline:** $O(N)$ HTTP requests per reorder (where $N$ is the number of items reordered).
- **Improvement:** $O(1)$ HTTP requests per reorder.
This mathematically guarantees a significant reduction in connection overhead and latency per operation. All test suites pass seamlessly with this refactor.

---
*PR created automatically by Jules for task [14611603823812881661](https://jules.google.com/task/14611603823812881661) started by @mrembert*