### PR TITLE
🧹 [Code Health] Refactor store reducer delete actions

### DIFF
--- a/src/storeReducer.ts
+++ b/src/storeReducer.ts
@@ -146,9 +146,9 @@ export function reducer(state: AppState, action: Action): AppState {
             return { ...state, collections: newCollections };
         }
         case 'DELETE_BULLET': {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { [action.payload.id]: deleted, ...remainingBullets } = state.bullets;
-            return { ...state, bullets: remainingBullets };
+            const newBullets = { ...state.bullets };
+            delete newBullets[action.payload.id];
+            return { ...state, bullets: newBullets };
         }
         case 'DELETE_BULLETS': {
             const newBullets = { ...state.bullets };
@@ -200,11 +200,11 @@ export function reducer(state: AppState, action: Action): AppState {
             };
         }
         case 'DELETE_COLLECTION': {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { [action.payload.id]: deleted, ...remainingCollections } = state.collections;
+            const newCollections = { ...state.collections };
+            delete newCollections[action.payload.id];
             return {
                 ...state,
-                collections: remainingCollections
+                collections: newCollections
             };
         }
         case 'TOGGLE_PREFERENCE': {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was removing disabled eslint rules (`eslint-disable-next-line @typescript-eslint/no-unused-vars`) and the corresponding unused variable that resulted from destructuring when deleting a collection (and a bullet).

💡 **Why:** The previous pattern used destructuring to pull out the deleted item but left the `deleted` variable unused. By instead creating a shallow copy and explicitly calling `delete`, the code explicitly shows its intent and avoids creating unnecessary variables. It also matches the pattern used elsewhere in the reducer (e.g. `DELETE_BULLETS`).

✅ **Verification:** Ran `npm run test` to verify no functionality was broken, including all reducer tests. Code review was also requested and passed.

✨ **Result:** Improved maintainability and consistency in `src/storeReducer.ts`. The disabled eslint rules are removed and there are no unused variables left behind.

---
*PR created automatically by Jules for task [7011968659733675407](https://jules.google.com/task/7011968659733675407) started by @mrembert*