### PR TITLE
feat: add project nesting to open tasks view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,6 +4375,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4384,6 +4385,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6429,6 +6431,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {

--- a/src/components/BacklogView.tsx
+++ b/src/components/BacklogView.tsx
@@ -1,16 +1,20 @@
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useStore } from '../store';
-import { BulletItem } from './BulletItem';
-import { calculateDepth } from '../lib/bulletUtils';
+import { TaskGroupList } from './TaskGroupList';
 import type { Bullet } from '../types';
-import { Archive, AlertCircle } from 'lucide-react';
+import { Archive, AlertCircle, Grid, Layers, ArrowUpDown } from 'lucide-react';
 import { format, parseISO, isBefore, startOfDay } from 'date-fns';
 
 export function BacklogView() {
-    const { state } = useStore();
+    const { state, dispatch } = useStore();
+    const { groupByProject, sortByType } = state.preferences;
+    const [isRearrangeMode, setIsRearrangeMode] = useState(false);
 
-    const { openTasks, visibleIdsSet } = useMemo(() => {
+    const toggleGrouping = () => dispatch({ type: 'TOGGLE_PREFERENCE', payload: { key: 'groupByProject' } });
+    const toggleSortType = () => dispatch({ type: 'TOGGLE_PREFERENCE', payload: { key: 'sortByType' } });
+
+    const { openTasks } = useMemo(() => {
         const today = startOfDay(new Date());
         const filtered = (Object.values(state.bullets) as Bullet[])
             .filter((b: Bullet) => {
@@ -34,13 +38,9 @@ export function BacklogView() {
             });
 
         return {
-            openTasks: filtered,
-            visibleIdsSet: new Set(filtered.map((b: Bullet) => b.id))
+            openTasks: filtered
         };
     }, [state.bullets]);
-
-    const undatedTasks = openTasks.filter((b: Bullet) => !b.date);
-    const datedTasks = openTasks.filter((b: Bullet) => b.date);
 
     return (
         <div style={{ maxWidth: '800px', margin: '0 auto' }}>
@@ -53,6 +53,41 @@ export function BacklogView() {
                     </p>
                 </div>
             </header>
+
+            <div className="view-controls" style={{
+                display: 'flex',
+                gap: '0.5rem',
+                marginBottom: '1rem',
+                justifyContent: 'flex-end'
+            }}>
+                <button
+                    onClick={() => setIsRearrangeMode(!isRearrangeMode)}
+                    className={`btn ${isRearrangeMode ? 'btn-primary' : 'btn-ghost'} mobile-only`}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
+                    title={isRearrangeMode ? "Done Rearranging" : "Rearrange Tasks"}
+                >
+                    <ArrowUpDown size={16} />
+                    {isRearrangeMode ? " Done" : " Rearrange"}
+                </button>
+                <button
+                    onClick={toggleGrouping}
+                    className={`btn ${groupByProject ? 'btn-primary' : 'btn-ghost'}`}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
+                    title={groupByProject ? "Ungroup" : "Group by Project"}
+                >
+                    {groupByProject ? <Grid size={16} /> : <Layers size={16} />}
+                    {groupByProject ? " Nested" : " Flat"}
+                </button>
+                <button
+                    onClick={toggleSortType}
+                    className={`btn ${sortByType ? 'btn-primary' : 'btn-ghost'}`}
+                    style={{ fontSize: '0.8rem', padding: '0.25rem 0.5rem' }}
+                    title={sortByType ? "Sorted by Type" : "Sort by Custom Order"}
+                >
+                    {sortByType ? <Layers size={16} /> : <Grid size={16} />}
+                    {sortByType ? " By Type" : " Custom"}
+                </button>
+            </div>
 
             {openTasks.length === 0 ? (
                 <div style={{
@@ -68,11 +103,16 @@ export function BacklogView() {
                     <p style={{ fontSize: '1.2rem' }}>You're all caught up!</p>
                     <p style={{ fontSize: '0.9rem', opacity: 0.8 }}>No open tasks found.</p>
                 </div>
+            ) : groupByProject ? (
+                <TaskGroupList
+                    bullets={openTasks}
+                    enableDragAndDrop={true}
+                    isRearrangeMode={isRearrangeMode}
+                />
             ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
-
                     {/* Undated Section */}
-                    {undatedTasks.length > 0 && (
+                    {openTasks.filter((b: Bullet) => !b.date).length > 0 && (
                         <div>
                             <h3 style={{
                                 fontSize: '0.9rem',
@@ -88,21 +128,17 @@ export function BacklogView() {
                                 <AlertCircle size={14} />
                                 Inbox / Undated
                             </h3>
-                            <div>
-                                {undatedTasks.map((bullet: Bullet) => (
-                                    <BulletItem
-                                        key={bullet.id}
-                                        bullet={bullet}
-                                        depth={calculateDepth(bullet, state.bullets, visibleIdsSet)}
-                                    />
-                                ))}
-                            </div>
+                            <TaskGroupList
+                                bullets={openTasks.filter((b: Bullet) => !b.date)}
+                                enableDragAndDrop={false}
+                                isRearrangeMode={isRearrangeMode}
+                            />
                         </div>
                     )}
 
                     {/* Dated Sections */}
-                    {Array.from(new Set(datedTasks.map((b: Bullet) => b.date as string))).map((date: string) => {
-                        const tasksForDate = datedTasks.filter((b: Bullet) => b.date === date);
+                    {Array.from(new Set(openTasks.filter((b: Bullet) => b.date).map((b: Bullet) => b.date as string))).map((date: string) => {
+                        const tasksForDate = openTasks.filter((b: Bullet) => b.date === date);
                         return (
                             <div key={date}>
                                 <h3 style={{
@@ -119,15 +155,11 @@ export function BacklogView() {
                                     <AlertCircle size={14} />
                                     {format(parseISO(date), 'EEEE, MMMM do')}
                                 </h3>
-                                <div>
-                                    {tasksForDate.map((bullet: Bullet) => (
-                                        <BulletItem
-                                            key={bullet.id}
-                                            bullet={bullet}
-                                            depth={calculateDepth(bullet, state.bullets, visibleIdsSet)}
-                                        />
-                                    ))}
-                                </div>
+                                <TaskGroupList
+                                    bullets={tasksForDate}
+                                    enableDragAndDrop={false}
+                                    isRearrangeMode={isRearrangeMode}
+                                />
                             </div>
                         );
                     })}


### PR DESCRIPTION
Closes #123

This PR introduces project nesting to the Open Tasks (Backlog) view based on user preference.

**Changes:**
1. **View Controls:** Added the `view-controls` header to `BacklogView.tsx` with toggles for Rearranging, Grouping (Nested/Flat), and Sorting (Custom/By Type).
2. **TaskGroupList Integration:** Replaced the direct `BulletItem` map with `TaskGroupList`.
    * When "Group by Project" (`groupByProject`) is enabled, the view completely ignores date grouping and renders a single `TaskGroupList` containing all open tasks, allowing them to be nested under their respective projects. This supports drag-and-drop out of the box.
    * When disabled (Flat mode), the view maintains its original behavior of sectioning tasks by date (Inbox/Undated, then chronological), rendering individual `TaskGroupLists` for each section with drag-and-drop disabled to maintain cross-date safety.
3. **Clean up:** Removed the local `calculateDepth` call and `visibleIdsSet` as `TaskGroupList` handles internal depth calculation and visibility sets.

**Testing:**
- Verified layout and toggles locally using Playwright screenshots.
- Verified that empty states still render correctly.
- Confirmed test suite still passes.

---
*PR created automatically by Jules for task [278733578458736914](https://jules.google.com/task/278733578458736914) started by @mrembert*