### PR TITLE
Share cumulative meeting notes across recurring occurrences

### DIFF
--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -5,6 +5,7 @@ import { X, Save, Trash } from 'lucide-react';
 import { RichTextEditor } from './RichTextEditor';
 import { cleanNoteContent } from '../lib/noteUtils.ts';
 import { v4 as uuidv4 } from 'uuid';
+import { getRecurringBulletIds } from '../lib/bulletUtils';
 
 interface NoteEditorProps {
     bulletId: string;
@@ -29,19 +30,35 @@ export function NoteEditor({ bulletId, onClose }: NoteEditorProps) {
 
     const handleClose = () => {
         // Always save the latest content from the ref
-        dispatch({
-            type: 'UPDATE_BULLET',
-            payload: { id: bulletId, longFormContent: contentRef.current }
-        });
+        if (bullet.recurringId) {
+            const ids = getRecurringBulletIds(bullet, state.bullets);
+            dispatch({
+                type: 'UPDATE_BULLETS',
+                payload: { ids, updates: { longFormContent: contentRef.current } }
+            });
+        } else {
+            dispatch({
+                type: 'UPDATE_BULLET',
+                payload: { id: bulletId, longFormContent: contentRef.current }
+            });
+        }
         onClose();
     };
 
     const handleDelete = () => {
         if (window.confirm('Are you sure you want to delete this note?')) {
-            dispatch({
-                type: 'UPDATE_BULLET',
-                payload: { id: bulletId, longFormContent: '' }
-            });
+            if (bullet.recurringId) {
+                const ids = getRecurringBulletIds(bullet, state.bullets);
+                dispatch({
+                    type: 'UPDATE_BULLETS',
+                    payload: { ids, updates: { longFormContent: '' } }
+                });
+            } else {
+                dispatch({
+                    type: 'UPDATE_BULLET',
+                    payload: { id: bulletId, longFormContent: '' }
+                });
+            }
             onClose();
         }
     };

--- a/src/lib/bulletUtils.test.ts
+++ b/src/lib/bulletUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { calculateDepth, getEffectiveCollectionId } from './bulletUtils.ts';
+import { calculateDepth, getEffectiveCollectionId, getRecurringBulletIds } from './bulletUtils.ts';
 import type { Bullet } from '../types';
 
 const mockBullet = (id: string, parentNoteId?: string): Bullet => ({
@@ -179,5 +179,32 @@ describe('Project Inheritance Scenarios', () => {
         const state = { 'task1': task }; // deletedNote is missing
 
         assert.strictEqual(getEffectiveCollectionId(task, state), undefined);
+    });
+});
+
+describe('getRecurringBulletIds', () => {
+    it('returns only own ID if bullet is not recurring', () => {
+        const bullet = mockBulletWithProps('1', { recurringId: undefined });
+        const state = { '1': bullet };
+        const ids = getRecurringBulletIds(bullet, state);
+        assert.deepStrictEqual(ids, ['1']);
+    });
+
+    it('returns only own ID if bullet is recurring but recurringId is null', () => {
+        const bullet = mockBulletWithProps('1', { recurringId: null });
+        const state = { '1': bullet };
+        const ids = getRecurringBulletIds(bullet, state);
+        assert.deepStrictEqual(ids, ['1']);
+    });
+
+    it('returns all matching IDs if bullet is recurring', () => {
+        const b1 = mockBulletWithProps('1', { recurringId: 'rec-1' });
+        const b2 = mockBulletWithProps('2', { recurringId: 'rec-1' });
+        const b3 = mockBulletWithProps('3', { recurringId: 'rec-2' }); // different recurrence
+        const state = { '1': b1, '2': b2, '3': b3 };
+
+        const ids = getRecurringBulletIds(b1, state);
+        // Should find '1' and '2' which share 'rec-1', but not '3'
+        assert.deepStrictEqual(ids.sort(), ['1', '2']);
     });
 });

--- a/src/lib/bulletUtils.ts
+++ b/src/lib/bulletUtils.ts
@@ -62,3 +62,17 @@ export function getEffectiveCollectionId(
 
     return undefined;
 }
+
+/**
+ * Finds all bullet IDs that share the same recurringId as the given bullet.
+ * If the bullet does not have a recurringId, it returns an array containing only the given bullet's ID.
+ */
+export function getRecurringBulletIds(
+    bullet: Bullet,
+    allBullets: Record<string, Bullet>
+): string[] {
+    if (!bullet.recurringId) return [bullet.id];
+    return Object.values(allBullets)
+        .filter(b => b.recurringId === bullet.recurringId)
+        .map(b => b.id);
+}


### PR DESCRIPTION
Allows recurring meetings to share a single, cumulative notes thread. When notes are updated or deleted on any instance of a recurring meeting series, the change is automatically propagated to all other instances of the same recurrence series using a single batch update action. This guarantees note consistency and seamless workflow continuity.

Fixes #70

---
*PR created automatically by Jules for task [4325333768001560015](https://jules.google.com/task/4325333768001560015) started by @mrembert*